### PR TITLE
Remove duplicate BackToTop from Diagnostic page

### DIFF
--- a/src/pages/Diagnostic.tsx
+++ b/src/pages/Diagnostic.tsx
@@ -7,7 +7,6 @@ import DiagnosticElcsContent from '../components/diagnostic/DiagnosticElcsConten
 import DiagnosticPsdContent from '../components/diagnostic/DiagnosticPsdContent';
 import DiagnosticRestaurantContent from '../components/diagnostic/DiagnosticRestaurantContent';
 import { ElcsDataProvider } from '../components/diagnostic/ElcsDataContext';
-import BackToTop from '../components/BackToTop';
 
 const Diagnostic = () => {
   return (
@@ -67,7 +66,6 @@ const Diagnostic = () => {
       </section>
 
       <Footer />
-      <BackToTop />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove the BackToTop import and component from the Diagnostic page so the floating button is only provided by the App wrapper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfc237821483319ed60cbe5667a0a9