### PR TITLE
Improve ARIA wiring for mobile navigation toggle

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -37,8 +37,10 @@ const Navbar = ({ showLogo = false }: NavbarProps) => {
     setMobileMenuOpen(!mobileMenuOpen);
   };
 
+  const mobileMenuId = 'mobile-menu';
+
   return (
-    <header 
+    <header
       className={cn(
         "bg-white border-b border-gray-200 py-4 px-6 sticky top-0 z-50 transition-all duration-300",
         isScrolled ? "shadow-md py-2" : ""
@@ -48,17 +50,20 @@ const Navbar = ({ showLogo = false }: NavbarProps) => {
         <Logo showLogo={showLogo} />
         
         {/* Menu hamburger pour mobile */}
-        <button 
+        <button
           className="md:hidden p-2 rounded-md text-french-blue hover:bg-blue-50"
           onClick={toggleMobileMenu}
           aria-label="Menu Navigation"
+          aria-expanded={mobileMenuOpen}
+          aria-controls={mobileMenuId}
         >
           <Menu size={24} />
         </button>
-        
+
         {/* Menu mobile */}
-        <MobileMenu 
-          mobileMenuOpen={mobileMenuOpen} 
+        <MobileMenu
+          id={mobileMenuId}
+          mobileMenuOpen={mobileMenuOpen}
           setMobileMenuOpen={setMobileMenuOpen}
           isActive={isActive}
         />

--- a/src/components/navigation/MobileMenu.tsx
+++ b/src/components/navigation/MobileMenu.tsx
@@ -4,17 +4,22 @@ import { cn } from '@/lib/utils';
 import MobileNavItem from './MobileNavItem';
 
 interface MobileMenuProps {
+  id?: string;
   mobileMenuOpen: boolean;
   setMobileMenuOpen: (open: boolean) => void;
   isActive: (path: string) => boolean;
 }
 
-const MobileMenu = ({ mobileMenuOpen, setMobileMenuOpen, isActive }: MobileMenuProps) => {
+const MobileMenu = ({ id, mobileMenuOpen, setMobileMenuOpen, isActive }: MobileMenuProps) => {
   return (
-    <div className={cn(
-      "fixed inset-y-0 right-0 transform w-64 bg-white shadow-xl z-50 transition-transform duration-300 ease-in-out md:hidden",
-      mobileMenuOpen ? "translate-x-0" : "translate-x-full"
-    )}>
+    <div
+      id={id}
+      aria-hidden={!mobileMenuOpen}
+      className={cn(
+        "fixed inset-y-0 right-0 transform w-64 bg-white shadow-xl z-50 transition-transform duration-300 ease-in-out md:hidden",
+        mobileMenuOpen ? "translate-x-0" : "translate-x-full"
+      )}
+    >
       <div className="flex flex-col h-full pt-16 px-4">
         <button 
           className="absolute top-4 right-4 p-2 rounded-full text-french-blue hover:bg-blue-50"


### PR DESCRIPTION
## Summary
- add a stable identifier for the mobile navigation panel and wire it to the hamburger toggle button via `aria-controls`
- expose the menu's open state to assistive technologies through `aria-expanded` on the button and `aria-hidden` on the panel container

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc2436efc8331aaeb1062ed59a112