### PR TITLE
Enhance PSD tabs hover interaction

### DIFF
--- a/src/components/PSDTabs.tsx
+++ b/src/components/PSDTabs.tsx
@@ -12,24 +12,39 @@ const PSDTabs = () => {
   return (
     <Tabs defaultValue="axe1" className="w-full">
       <TabsList className="grid grid-cols-5 mb-8">
-        <TabsTrigger value="axe1" className="flex flex-col items-center py-3 data-[state=active]:text-french-blue">
-          <Target size={20} className="mb-1" />
+        <TabsTrigger
+          value="axe1"
+          className="flex flex-col items-center py-3 transition-transform duration-200 hover:animate-tab-pulse data-[state=active]:text-french-blue"
+        >
+          <Target size={24} className="mb-1" />
           <span className="text-xs">Axe 1</span>
         </TabsTrigger>
-        <TabsTrigger value="axe2" className="flex flex-col items-center py-3 data-[state=active]:text-french-blue">
-          <Users size={20} className="mb-1" />
+        <TabsTrigger
+          value="axe2"
+          className="flex flex-col items-center py-3 transition-transform duration-200 hover:animate-tab-pulse data-[state=active]:text-french-blue"
+        >
+          <Users size={24} className="mb-1" />
           <span className="text-xs">Axe 2</span>
         </TabsTrigger>
-        <TabsTrigger value="axe3" className="flex flex-col items-center py-3 data-[state=active]:text-french-blue">
-          <Sparkles size={20} className="mb-1" />
+        <TabsTrigger
+          value="axe3"
+          className="flex flex-col items-center py-3 transition-transform duration-200 hover:animate-tab-pulse data-[state=active]:text-french-blue"
+        >
+          <Sparkles size={24} className="mb-1" />
           <span className="text-xs">Axe 3</span>
         </TabsTrigger>
-        <TabsTrigger value="axe4" className="flex flex-col items-center py-3 data-[state=active]:text-french-blue">
-          <GraduationCap size={20} className="mb-1" />
+        <TabsTrigger
+          value="axe4"
+          className="flex flex-col items-center py-3 transition-transform duration-200 hover:animate-tab-pulse data-[state=active]:text-french-blue"
+        >
+          <GraduationCap size={24} className="mb-1" />
           <span className="text-xs">Axe 4</span>
         </TabsTrigger>
-        <TabsTrigger value="axe5" className="flex flex-col items-center py-3 data-[state=active]:text-french-blue">
-          <LayoutDashboard size={20} className="mb-1" />
+        <TabsTrigger
+          value="axe5"
+          className="flex flex-col items-center py-3 transition-transform duration-200 hover:animate-tab-pulse data-[state=active]:text-french-blue"
+        >
+          <LayoutDashboard size={24} className="mb-1" />
           <span className="text-xs">Transversal</span>
         </TabsTrigger>
       </TabsList>

--- a/src/index.css
+++ b/src/index.css
@@ -121,6 +121,10 @@
   .card-hover {
     @apply transition-all duration-300 hover:shadow-lg hover:-translate-y-1;
   }
+
+  .animate-tab-pulse {
+    animation: tab-hover-pulse 0.2s ease-in-out;
+  }
 }
 
 /* Animation supplémentaire pour les éléments qui entrent dans le viewport */
@@ -155,6 +159,18 @@
   100% {
     opacity: 1;
     transform: translateX(0);
+  }
+}
+
+@keyframes tab-hover-pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- enlarge the tab icons used for the PSD navigation
- add a shared hover animation that briefly scales the icon and label for each tab
- define the supporting animation keyframes in the global stylesheet

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfde7116e083319ef3853fec1d526c