### PR TITLE
Localise la page 404 et conserve la navigation côté client

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -15,10 +15,12 @@ const NotFound = () => {
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
+        <p className="text-xl text-gray-600 mb-4">
+          Oups ! Cette page est introuvable.
+        </p>
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
+          Retour à l'accueil
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- localise le contenu de la page 404 en français
- utilise le composant Link de react-router-dom pour le retour à l'accueil

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02f83ee1c83318dd730df1ba1b69d