### PR TITLE
Transforme les liens des actions prioritaires en boutons CTA

### DIFF
--- a/src/components/PSDAxeLayout.tsx
+++ b/src/components/PSDAxeLayout.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { ExternalLink } from 'lucide-react';
+import { ShieldCheck, Utensils } from 'lucide-react';
 
 interface ObjectifItem {
   text: string;
@@ -53,18 +53,43 @@ const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
         <div>
           <h4 className="font-semibold text-gray-900 mb-2">Actions prioritaires</h4>
           <ul className="list-disc pl-5 space-y-1 text-gray-700 font-raleway">
-            {actions.map((item, index) => (
-              <li key={index} className="list-item">
-                <div className="flex items-center gap-1">
-                  <span dangerouslySetInnerHTML={{ __html: item.text }}></span>
-                  {item.link && (
-                    <Link to={item.link} className="inline-flex items-center text-french-blue hover:text-french-blue/80">
-                      <ExternalLink size={16} />
-                    </Link>
-                  )}
-                </div>
-              </li>
-            ))}
+            {actions.map((item, index) => {
+              const hasLink = Boolean(item.link);
+              const textContent = item.text.toLowerCase();
+              const iconType = textContent.includes('harcèlement')
+                ? 'harcelement'
+                : textContent.includes('restauration')
+                ? 'restauration'
+                : null;
+              const IconComponent = iconType === 'harcelement' ? ShieldCheck : iconType === 'restauration' ? Utensils : null;
+              const ariaLabelSuffix = iconType === 'harcelement'
+                ? 'Prévention du harcèlement'
+                : iconType === 'restauration'
+                ? 'Restauration scolaire'
+                : '';
+
+              if (!hasLink || !IconComponent || !item.link) {
+                return (
+                  <li key={index} className="list-item">
+                    <span dangerouslySetInnerHTML={{ __html: item.text }}></span>
+                  </li>
+                );
+              }
+
+              return (
+                <li key={index} className="action-item">
+                  <span className="action-text" dangerouslySetInnerHTML={{ __html: item.text }}></span>
+                  <Link
+                    to={item.link}
+                    className="btn-link"
+                    aria-label={`En savoir plus – ${ariaLabelSuffix}`}
+                  >
+                    <IconComponent className="icon" size={18} aria-hidden="true" />
+                    <span>En savoir plus</span>
+                  </Link>
+                </li>
+              );
+            })}
           </ul>
         </div>
         

--- a/src/index.css
+++ b/src/index.css
@@ -187,3 +187,54 @@
 .animate-pulse-slow {
   animation: pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
+
+.action-item {
+  list-style: none;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: start;
+  gap: 0.75rem;
+  margin: 0.5rem 0;
+}
+
+.action-text {
+  display: block;
+}
+
+.btn-link {
+  border: 1px solid #d0d5dd;
+  padding: 0.625rem 0.9rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 44px;
+  color: #1d4ed8;
+  font-weight: 600;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+.btn-link:hover {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  text-decoration: underline;
+}
+
+.btn-link:focus-visible {
+  outline: 2px solid #1d4ed8;
+  outline-offset: 2px;
+}
+
+.icon {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 640px) {
+  .action-item {
+    grid-template-columns: 1fr;
+  }
+
+  .btn-link {
+    justify-self: start;
+  }
+}


### PR DESCRIPTION
## Summary
- convertit les actions prioritaires avec lien en boutons « En savoir plus » avec icônes Lucide et aria-labels précis
- ajoute les styles globaux pour la grille des items et l’apparence du bouton secondaire réactif

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d03a1f8c38833183ebadd61fbf9bf0