### PR TITLE
Refactor PSD axes with color-coded card layout

### DIFF
--- a/src/components/PSDAxe1.tsx
+++ b/src/components/PSDAxe1.tsx
@@ -1,210 +1,165 @@
-
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { BarChart3, ListChecks, Target, ShieldCheck, Utensils } from 'lucide-react';
+import {
+  HeartPulse,
+  Leaf,
+  Megaphone,
+  ShieldCheck,
+  Snowflake,
+  UsersRound,
+  Utensils,
+} from 'lucide-react';
+import PSDAxeLayout from './PSDAxeLayout';
 
 const PSDAxe1 = () => {
-  const summaryCards = [
-    {
-      id: 'details-objectifs',
-      title: 'Objectifs',
-      icon: Target,
-      ariaLabel: 'Voir le détail des objectifs',
-      items: [
-        { icon: '🌱', label: 'Bien-être & accompagnement' },
-        { icon: '🤝', label: 'Climat & coopération' },
-        { icon: '🍽️', label: 'Services durables' }
-      ]
-    },
-    {
-      id: 'details-actions',
-      title: 'Actions prioritaires',
-      icon: ListChecks,
-      ariaLabel: 'Voir le détail des actions prioritaires',
-      items: [
-        { icon: '❄️', label: 'Rafraîchissement durable' },
-        { icon: '🛡️', label: 'Prévention du harcèlement' },
-        { icon: '🗣️', label: 'Participation & expression' },
-        { icon: '🍽️', label: 'Restauration scolaire' }
-      ]
-    },
-    {
-      id: 'details-indicateurs',
-      title: 'Indicateurs',
-      icon: BarChart3,
-      ariaLabel: 'Voir le détail des indicateurs',
-      items: [
-        { icon: '📈', label: '+15 pts satisfaction' },
-        { icon: '🌡️', label: '≥ 80% salles confort' },
-        { icon: '🌿', label: 'Plan annuel E³D' }
-      ]
-    }
-  ];
+  const summary = {
+    objectives: [
+      { icon: '🌱', label: 'Bien-être & accompagnement' },
+      { icon: '🤝', label: 'Climat & coopération' },
+      { icon: '🍽️', label: 'Services durables' },
+    ],
+    actions: [
+      {
+        label: 'Rafraîchissement durable',
+        icon: Snowflake,
+        iconClassName: 'text-sky-600',
+      },
+      {
+        label: 'Parcours santé-bien-être',
+        icon: HeartPulse,
+        iconClassName: 'text-rose-600',
+      },
+      {
+        label: 'Prévention du harcèlement',
+        icon: ShieldCheck,
+        iconClassName: 'text-emerald-600',
+        link: '/protocole-phare',
+        linkAriaLabel: 'En savoir plus – Prévention du harcèlement',
+      },
+      {
+        label: 'Participation & expression',
+        icon: Megaphone,
+        iconClassName: 'text-purple-600',
+      },
+      {
+        label: 'Parentalité & coéducation',
+        icon: UsersRound,
+        iconClassName: 'text-orange-600',
+      },
+      {
+        label: 'Restauration scolaire',
+        icon: Utensils,
+        iconClassName: 'text-amber-600',
+        link: '/construction-cantine',
+        linkAriaLabel: 'En savoir plus – Restauration scolaire',
+      },
+      {
+        label: 'Politique E³D consolidée',
+        icon: Leaf,
+        iconClassName: 'text-green-700',
+      },
+    ],
+    indicators: [
+      { label: 'Satisfaction climat / cantine', value: '+15 pts' },
+      { label: 'Confort thermique', value: '≥ 80 % salles' },
+      { label: 'Engagement E³D', value: 'Plan annuel publié' },
+    ],
+  };
 
   const objectifs = [
     {
       text:
-        '<strong>Bien-être et accompagnement des élèves</strong> : Garantir un <strong>environnement scolaire sain, climatisé et agréable</strong>, développer une <strong>culture du bien-être physique, mental, social et environnemental</strong> et répondre aux <strong>besoins particuliers des élèves</strong>.'
+        '<strong>Bien-être et accompagnement des élèves</strong> : Garantir un <strong>environnement scolaire sain, climatisé et agréable</strong>, développer une <strong>culture du bien-être physique, mental, social et environnemental</strong> et répondre aux <strong>besoins particuliers des élèves</strong>.',
     },
     {
       text:
-        '<strong>Climat scolaire et coopération éducative</strong> : Renforcer la <strong>confiance et la coopération</strong> entre élèves, familles et personnels, <strong>responsabiliser les élèves</strong> dans la vie de l\'établissement et consolider un <strong>climat scolaire</strong> fondé sur des règles et des valeurs partagées.'
+        '<strong>Climat scolaire et coopération éducative</strong> : Renforcer la <strong>confiance et la coopération</strong> entre élèves, familles et personnels, <strong>responsabiliser les élèves</strong> dans la vie de l\'établissement et consolider un <strong>climat scolaire</strong> fondé sur des règles et des valeurs partagées.',
     },
     {
       text:
-        '<strong>Qualité et durabilité des services</strong> : Améliorer la <strong>qualité des services</strong> (restauration, transport, hygiène) et pérenniser l\'engagement du LFJP en matière de <strong>développement durable</strong> dans la dynamique <strong>E³D</strong>.'
-    }
+        '<strong>Qualité et durabilité des services</strong> : Améliorer la <strong>qualité des services</strong> (restauration, transport, hygiène) et pérenniser l\'engagement du LFJP en matière de <strong>développement durable</strong> dans la dynamique <strong>E³D</strong>.',
+    },
   ];
 
   const actions = [
-    { text: '<strong>Rafraîchissement durable des salles</strong> : <strong>plan de climatisation progressive</strong> et solutions écologiques (ombrages, végétalisation, rénovation)' },
-    { text: '<strong>Parcours santé-bien-être</strong> : hygiène, alimentation, activité physique et <strong>équilibre mental</strong>' },
-    { text: '<strong>Prévention du harcèlement</strong> : <strong>médiateurs élèves</strong>, pratiques restauratives, programme <strong>pHARe</strong>', link: '/protocole-phare' },
-    { text: '<strong>Expression et participation</strong> : conseils de vie, <strong>budgets participatifs</strong>, comités mixtes' },
-    { text: '<strong>Parentalité et coéducation</strong> : rencontres et ateliers pour mieux suivre la scolarité' },
-    { text: '<strong>Restauration scolaire</strong> : audit, consultation des usagers, mise en œuvre 2026-2027', link: '/construction-cantine' },
-    { text: 'Politique <strong>E³D</strong> consolidée : <strong>référents</strong> et <strong>éco-délégués</strong>, comité de pilotage, projets interdisciplinaires, plan d\'action annuel aligné <strong>EFE³D</strong>' }
+    {
+      text:
+        '<strong>Rafraîchissement durable des salles</strong> : <strong>plan de climatisation progressive</strong> et solutions écologiques (ombrages, végétalisation, rénovation)',
+    },
+    {
+      text:
+        '<strong>Parcours santé-bien-être</strong> : hygiène, alimentation, activité physique et <strong>équilibre mental</strong>',
+    },
+    {
+      text:
+        '<strong>Prévention du harcèlement</strong> : <strong>médiateurs élèves</strong>, pratiques restauratives, programme <strong>pHARe</strong>',
+      link: '/protocole-phare',
+      linkAriaLabel: 'En savoir plus – Prévention du harcèlement',
+      linkIcon: ShieldCheck,
+    },
+    {
+      text:
+        '<strong>Expression et participation</strong> : conseils de vie, <strong>budgets participatifs</strong>, comités mixtes',
+    },
+    {
+      text:
+        '<strong>Parentalité et coéducation</strong> : rencontres et ateliers pour mieux suivre la scolarité',
+    },
+    {
+      text:
+        '<strong>Restauration scolaire</strong> : audit, consultation des usagers, mise en œuvre 2026-2027',
+      link: '/construction-cantine',
+      linkAriaLabel: 'En savoir plus – Restauration scolaire',
+      linkIcon: Utensils,
+    },
+    {
+      text:
+        'Politique <strong>E³D</strong> consolidée : <strong>référents</strong> et <strong>éco-délégués</strong>, comité de pilotage, projets interdisciplinaires, plan d\'action annuel aligné <strong>EFE³D</strong>',
+    },
   ];
-  
+
   const indicators = [
-    { text: '<strong>Taux d\'élèves</strong> se déclarant « <strong>bien au LFJP</strong> » (objectif : <strong>+15 pts</strong> au lycée)' },
-    { text: '<strong>Taux de satisfaction</strong> sur la climatisation, les sanitaires, la cantine (élèves et parents)' },
-    { text: '<strong>Nombre de familles accompagnées</strong> dans le cadre de dispositifs de soutien à la parentalité' },
-    { text: '<strong>Taux d\'élèves</strong> bénéficiant d\'un <strong>aménagement</strong> ou d\'un <strong>accompagnement pédagogique</strong>' },
-    { text: '<strong>Avancement du plan de restauration scolaire</strong> (étapes validées)' },
-    { text: '<strong>Taux de satisfaction global</strong> sur le <strong>climat scolaire</strong> (par enquête ELCS)' },
-    { text: '<strong>Nombre de projets E3D</strong> portés par cycle' },
-    { text: 'Maintien du <strong>label EFE3D niveau 3</strong> à chaque renouvellement triennal' }
+    {
+      text:
+        '<strong>Taux d\'élèves</strong> se déclarant « <strong>bien au LFJP</strong> » (objectif : <strong>+15 pts</strong> au lycée)',
+    },
+    {
+      text:
+        '<strong>Taux de satisfaction</strong> sur la climatisation, les sanitaires, la cantine (élèves et parents)',
+    },
+    {
+      text:
+        '<strong>Nombre de familles accompagnées</strong> dans le cadre de dispositifs de soutien à la parentalité',
+    },
+    {
+      text:
+        '<strong>Taux d\'élèves</strong> bénéficiant d\'un <strong>aménagement</strong> ou d\'un <strong>accompagnement pédagogique</strong>',
+    },
+    {
+      text:
+        '<strong>Avancement du plan de restauration scolaire</strong> (étapes validées)',
+    },
+    {
+      text:
+        '<strong>Taux de satisfaction global</strong> sur le <strong>climat scolaire</strong> (par enquête ELCS)',
+    },
+    {
+      text: '<strong>Nombre de projets E3D</strong> portés par cycle',
+    },
+    {
+      text: 'Maintien du <strong>label EFE3D niveau 3</strong> à chaque renouvellement triennal',
+    },
   ];
 
   return (
-    <div>
-      <h3 className="text-xl font-playfair font-bold text-french-blue mb-4">
-        AXE 1 – BIEN-ÊTRE ET EXPÉRIENCE DE LA COMMUNAUTÉ ÉDUCATIVE
-      </h3>
-      <p className="text-lg font-medium font-raleway text-gray-800 mb-8">
-        Renforcer un cadre scolaire propice à l'épanouissement, à l'inclusion et à la cohésion
-      </p>
-
-      <section className="grid gap-6 md:grid-cols-3">
-        {summaryCards.map((card) => {
-          const Icon = card.icon;
-
-          return (
-            <article
-              key={card.id}
-              className="flex flex-col rounded-2xl bg-white p-6 shadow-sm ring-1 ring-french-blue/10"
-            >
-              <div className="mb-4 flex items-center gap-3">
-                <span className="rounded-full bg-french-blue/10 p-2 text-french-blue">
-                  <Icon className="h-6 w-6" aria-hidden="true" />
-                </span>
-                <h4 className="text-lg font-semibold text-slate-900">{card.title}</h4>
-              </div>
-              <ul className="grid gap-2">
-                {card.items.map((item) => (
-                  <li
-                    key={item.label}
-                    className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700"
-                  >
-                    <span aria-hidden="true">{item.icon}</span>
-                    <span>{item.label}</span>
-                  </li>
-                ))}
-              </ul>
-              <div className="mt-6">
-                <a
-                  href={`#${card.id}`}
-                  className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-800 transition hover:bg-slate-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue"
-                  aria-label={card.ariaLabel}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    className="h-4 w-4"
-                    aria-hidden="true"
-                  >
-                    <path d="M14 3h7v7" strokeWidth="1.5" />
-                    <path d="M21 3 10 14" strokeWidth="1.5" />
-                    <rect x="3" y="7" width="10" height="14" rx="2" ry="2" strokeWidth="1.5" />
-                  </svg>
-                  <span>Voir le détail</span>
-                </a>
-              </div>
-            </article>
-          );
-        })}
-      </section>
-
-      <section className="mt-12 space-y-8">
-        <div
-          id="details-objectifs"
-          className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
-        >
-          <h4 className="mb-3 text-lg font-semibold text-slate-900">Objectifs détaillés</h4>
-          <ul className="list-disc space-y-2 pl-5 text-gray-700 font-raleway">
-            {objectifs.map((item, index) => (
-              <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
-            ))}
-          </ul>
-        </div>
-
-        <div id="details-actions" className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h4 className="mb-3 text-lg font-semibold text-slate-900">Actions prioritaires détaillées</h4>
-          <ul className="list-disc space-y-3 pl-5 text-gray-700 font-raleway">
-            {actions.map((item, index) => {
-              const hasLink = Boolean(item.link);
-              const textContent = item.text.toLowerCase();
-              const iconType = textContent.includes('harcèlement')
-                ? 'harcelement'
-                : textContent.includes('restauration')
-                ? 'restauration'
-                : null;
-              const IconComponent = iconType === 'harcelement' ? ShieldCheck : iconType === 'restauration' ? Utensils : null;
-              const ariaLabelSuffix = iconType === 'harcelement'
-                ? 'Prévention du harcèlement'
-                : iconType === 'restauration'
-                ? 'Restauration scolaire'
-                : '';
-
-              if (!hasLink || !IconComponent || !item.link) {
-                return (
-                  <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
-                );
-              }
-
-              return (
-                <li key={index} className="flex flex-wrap items-center gap-2">
-                  <span dangerouslySetInnerHTML={{ __html: item.text }}></span>
-                  <Link
-                    to={item.link}
-                    className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue"
-                    aria-label={`En savoir plus – ${ariaLabelSuffix}`}
-                  >
-                    <IconComponent className="h-4 w-4" aria-hidden="true" />
-                    <span>En savoir plus</span>
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-
-        <div
-          id="details-indicateurs"
-          className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
-        >
-          <h4 className="mb-3 text-lg font-semibold text-slate-900">Indicateurs détaillés</h4>
-          <ul className="list-disc space-y-2 pl-5 text-gray-700 font-raleway">
-            {indicators.map((item, index) => (
-              <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
-            ))}
-          </ul>
-        </div>
-      </section>
-    </div>
+    <PSDAxeLayout
+      axeId={1}
+      title="AXE 1 – BIEN-ÊTRE ET EXPÉRIENCE DE LA COMMUNAUTÉ ÉDUCATIVE"
+      subtitle="Renforcer un cadre scolaire propice à l'épanouissement, à l'inclusion et à la cohésion"
+      summary={summary}
+      objectifs={objectifs}
+      actions={actions}
+      indicators={indicators}
+    />
   );
 };
 

--- a/src/components/PSDAxe2.tsx
+++ b/src/components/PSDAxe2.tsx
@@ -1,35 +1,140 @@
 import React from 'react';
+import {
+  CalendarHeart,
+  Globe2,
+  Handshake,
+  Languages,
+  Plane,
+  Sprout,
+} from 'lucide-react';
 import PSDAxeLayout from './PSDAxeLayout';
 
 const PSDAxe2 = () => {
+  const summary = {
+    objectives: [
+      { icon: '🗣️', label: 'Plurilinguisme valorisé' },
+      { icon: '🌍', label: 'Ouverture internationale' },
+      { icon: '🤝', label: 'Dialogue interculturel' },
+    ],
+    actions: [
+      {
+        label: 'Plan Section internationale & BFI',
+        icon: Globe2,
+        iconClassName: 'text-emerald-600',
+        link: '/section-internationale-bfi',
+        linkAriaLabel: 'En savoir plus – Section internationale et BFI',
+      },
+      {
+        label: 'Voyages et jumelages',
+        icon: Plane,
+        iconClassName: 'text-sky-600',
+      },
+      {
+        label: 'Semaine des cultures',
+        icon: CalendarHeart,
+        iconClassName: 'text-amber-600',
+      },
+      {
+        label: 'Médiation interculturelle',
+        icon: Handshake,
+        iconClassName: 'text-rose-600',
+      },
+      {
+        label: 'Familles & langues du LFJP',
+        icon: Languages,
+        iconClassName: 'text-indigo-600',
+      },
+      {
+        label: 'Partenariats E³D',
+        icon: Sprout,
+        iconClassName: 'text-emerald-700',
+      },
+    ],
+    indicators: [
+      { label: 'Sections & certifications actives', value: 'SI & BFI 2026-2033' },
+      { label: 'Partenariats locaux et internationaux', value: '≥ 5 actifs' },
+      { label: 'Événements interculturels', value: 'Semaine annuelle' },
+    ],
+  };
+
   const objectifs = [
-    { text: 'Développer un environnement scolaire où la <strong>diversité des langues, cultures et nationalités</strong> présentes au LFJP devient un <strong>atout éducatif et citoyen</strong>.' },
-    { text: 'Renforcer la <strong>maîtrise des langues vivantes étrangères</strong> et du <strong>français langue de scolarisation</strong>, conformément aux orientations de l\'Éducation nationale et de l\'AEFE.' },
-    { text: 'Former des élèves capables de comprendre et d\'évoluer dans un <strong>monde multipolaire</strong>, ouverts à la <strong>pluralité des cultures, religions et visions du monde</strong>.' },
-    { text: 'Prévenir les <strong>chocs culturels</strong> en dotant les élèves de repères sociologiques et psychologiques favorisant la <strong>tolérance, le dialogue et l\'intercompréhension</strong>.' },
-    { text: 'Consolider les <strong>parcours éducatifs</strong> (Parcours citoyen, Parcours Avenir, PEAC) par des <strong>expériences interculturelles et internationales</strong>.' }
+    {
+      text:
+        'Développer un environnement scolaire où la <strong>diversité des langues, cultures et nationalités</strong> présentes au LFJP devient un <strong>atout éducatif et citoyen</strong>.',
+    },
+    {
+      text:
+        'Renforcer la <strong>maîtrise des langues vivantes étrangères</strong> et du <strong>français langue de scolarisation</strong>, conformément aux orientations de l\'Éducation nationale et de l\'AEFE.',
+    },
+    {
+      text:
+        'Former des élèves capables de comprendre et d\'évoluer dans un <strong>monde multipolaire</strong>, ouverts à la <strong>pluralité des cultures, religions et visions du monde</strong>.',
+    },
+    {
+      text:
+        'Prévenir les <strong>chocs culturels</strong> en dotant les élèves de repères sociologiques et psychologiques favorisant la <strong>tolérance, le dialogue et l\'intercompréhension</strong>.',
+    },
+    {
+      text:
+        'Consolider les <strong>parcours éducatifs</strong> (Parcours citoyen, Parcours Avenir, PEAC) par des <strong>expériences interculturelles et internationales</strong>.',
+    },
   ];
-  
+
   const actions = [
-    { text: '<strong>Sections et certifications internationales</strong> :<br/>• <strong>Déploiement du plan « Section Internationale et BFI »</strong> (2026-2033) <a href="/section-internationale-bfi" class="inline-flex items-center text-french-blue hover:text-french-blue/80"><svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg></a><br/>• Recrutement et formation d\'<strong>enseignants locuteurs natifs</strong> ou hautement qualifiés (niveau <strong>C2 CECRL</strong>) pour les disciplines non linguistiques et littéraires.' },
-    { text: '<strong>Ouverture internationale</strong> :<br/>• Développer les <strong>voyages scolaires thématiques</strong> (culturels, scientifiques, sportifs) en tant que leviers pédagogiques d\'ouverture au monde.<br/>• Explorer les <strong>jumelages avec d\'autres lycées français</strong> de l\'étranger et les partenariats <strong>Erasmus+/AEFE</strong>.' },
-    { text: '<strong>Ouverture locale</strong> :<br/>• Renforcer les <strong>coopérations avec les écoles et établissements voisins</strong> (activités conjointes, projets citoyens, actions artistiques et sportives).<br/>• Organiser une « <strong>Semaine des cultures</strong> » annuelle, durant laquelle les élèves présentent leurs langues, traditions et patrimoines culturels.' },
-    { text: '<strong>Vie scolaire et climat interculturel</strong> :<br/>• Favoriser la <strong>médiation et la prévention</strong> des incompréhensions interculturelles.<br/>• Intégrer les <strong>langues et cultures des familles</strong> dans la vie de l\'établissement (journées thématiques, interventions de parents).' },
-    { text: '<strong>Politique E3D</strong> avec maintien des <strong>17 objectifs de développement durable</strong>, demande de <strong>labellisation niveau 3</strong>, et présence d\'<strong>éco-délégués</strong>' }
+    {
+      text:
+        '<strong>Sections et certifications internationales</strong> :<br/>• <strong>Déploiement du plan « Section Internationale et BFI »</strong> (2026-2033)<br/>• Recrutement et formation d\'<strong>enseignants locuteurs natifs</strong> ou hautement qualifiés (niveau <strong>C2 CECRL</strong>) pour les disciplines non linguistiques et littéraires.',
+      link: '/section-internationale-bfi',
+      linkAriaLabel: 'En savoir plus – Section internationale et BFI',
+      linkIcon: Globe2,
+    },
+    {
+      text:
+        '<strong>Ouverture internationale</strong> :<br/>• Développer les <strong>voyages scolaires thématiques</strong> (culturels, scientifiques, sportifs) en tant que leviers pédagogiques d\'ouverture au monde.<br/>• Explorer les <strong>jumelages avec d\'autres lycées français</strong> de l\'étranger et les partenariats <strong>Erasmus+/AEFE</strong>.',
+    },
+    {
+      text:
+        '<strong>Ouverture locale</strong> :<br/>• Renforcer les <strong>coopérations avec les écoles et établissements voisins</strong> (activités conjointes, projets citoyens, actions artistiques et sportives).<br/>• Organiser une « <strong>Semaine des cultures</strong> » annuelle, durant laquelle les élèves présentent leurs langues, traditions et patrimoines culturels.',
+    },
+    {
+      text:
+        '<strong>Vie scolaire et climat interculturel</strong> :<br/>• Favoriser la <strong>médiation et la prévention</strong> des incompréhensions interculturelles.<br/>• Intégrer les <strong>langues et cultures des familles</strong> dans la vie de l\'établissement (journées thématiques, interventions de parents).',
+    },
+    {
+      text:
+        '<strong>Politique E3D</strong> avec maintien des <strong>17 objectifs de développement durable</strong>, demande de <strong>labellisation niveau 3</strong>, et présence d\'<strong>éco-délégués</strong>.',
+    },
   ];
-  
+
   const indicators = [
-    { text: 'Taux d\'élèves engagés dans des <strong>sections et certifications internationales</strong> (SI, BFI).' },
-    { text: 'Pourcentage d\'<strong>enseignants de LV et DNL locuteurs natifs</strong> ou certifiés C2.' },
-    { text: 'Nombre de <strong>partenariats locaux et internationaux</strong> actifs.' },
-    { text: 'Taux de satisfaction des élèves et familles concernant l\'<strong>ouverture culturelle et linguistique</strong> (enquêtes climats scolaires).' },
-    { text: 'Participation annuelle des élèves aux projets de la « <strong>Semaine des cultures</strong> » et aux <strong>jumelages</strong>.' }
+    {
+      text:
+        'Taux d\'élèves engagés dans des <strong>sections et certifications internationales</strong> (SI, BFI).',
+    },
+    {
+      text:
+        'Pourcentage d\'<strong>enseignants de LV et DNL locuteurs natifs</strong> ou certifiés C2.',
+    },
+    {
+      text:
+        'Nombre de <strong>partenariats locaux et internationaux</strong> actifs.',
+    },
+    {
+      text:
+        'Taux de satisfaction des élèves et familles concernant l\'<strong>ouverture culturelle et linguistique</strong> (enquêtes climats scolaires).',
+    },
+    {
+      text:
+        'Participation annuelle des élèves aux projets de la « <strong>Semaine des cultures</strong> » et aux <strong>jumelages</strong>.',
+    },
   ];
 
   return (
-    <PSDAxeLayout 
+    <PSDAxeLayout
+      axeId={2}
       title="AXE 2 – PLURILINGUISME, MULTICULTURALITÉ, OUVERTURE INTERNATIONALE ET LOCALE"
       subtitle="Cultiver la diversité linguistique et culturelle comme levier d'apprentissage et d'ouverture au monde"
+      summary={summary}
       objectifs={objectifs}
       actions={actions}
       indicators={indicators}

--- a/src/components/PSDAxe3.tsx
+++ b/src/components/PSDAxe3.tsx
@@ -1,44 +1,170 @@
-
 import React from 'react';
+import {
+  Code2,
+  Cpu,
+  FlaskConical,
+  GraduationCap,
+  Handshake,
+  Laptop,
+  Wifi,
+} from 'lucide-react';
 import PSDAxeLayout from './PSDAxeLayout';
 
 const PSDAxe3 = () => {
+  const summary = {
+    objectives: [
+      { icon: '💻', label: 'Parcours numérique structuré' },
+      { icon: '🧠', label: 'Culture IA & citoyenne' },
+      { icon: '🚀', label: 'Innovation créative' },
+    ],
+    actions: [
+      {
+        label: 'Curriculum numérique spiralaire',
+        icon: GraduationCap,
+        iconClassName: 'text-amber-600',
+      },
+      {
+        label: 'Initiation au code',
+        icon: Code2,
+        iconClassName: 'text-blue-600',
+      },
+      {
+        label: 'Module IA responsable',
+        icon: Cpu,
+        iconClassName: 'text-amber-600',
+      },
+      {
+        label: 'Laboratoire créatif',
+        icon: FlaskConical,
+        iconClassName: 'text-pink-600',
+      },
+      {
+        label: 'Plan « Un PC par lycéen »',
+        icon: Laptop,
+        iconClassName: 'text-emerald-600',
+        link: '/pc-par-lyceen',
+        linkAriaLabel: 'En savoir plus – Un PC par lycéen',
+      },
+      {
+        label: 'Connectivité et renouvellement',
+        icon: Wifi,
+        iconClassName: 'text-sky-600',
+      },
+      {
+        label: 'Partenariats & mécénats',
+        icon: Handshake,
+        iconClassName: 'text-amber-700',
+      },
+    ],
+    indicators: [
+      { label: 'Élèves certifiés PIX', value: '≥ 80 % cycle 4' },
+      { label: 'Projets numériques interdisciplinaires', value: '≥ 5 / an' },
+      { label: 'Équipement lycéen', value: '100 % d\'ici 2028' },
+    ],
+  };
+
   const objectifs = [
-    { text: 'Garantir un accès équitable et progressif aux <strong>compétences numériques</strong>, de l\'élémentaire à la terminale (<em>parcours numérique structuré</em>)' },
-    { text: 'Développer des <strong>compétences critiques, créatives et éthiques</strong> dans un monde numérique en évolution constante' },
-    { text: 'Permettre aux élèves de <strong>comprendre et maîtriser les outils numériques</strong>, y compris l\'<strong>intelligence artificielle</strong>, pour être <strong>acteurs et non consommateurs</strong>' },
-    { text: 'Promouvoir une <strong>culture numérique responsable et citoyenne</strong> : <em>cybersécurité, droit à l\'image, identité numérique, gestion du temps d\'écran</em>' },
-    { text: 'Renforcer la <strong>créativité numérique</strong>, l\'<strong>entrepreneuriat</strong> et les <strong>projets interconnectés avec le monde professionnel</strong> et les <strong>enjeux locaux</strong>' }
+    {
+      text:
+        'Garantir un accès équitable et progressif aux <strong>compétences numériques</strong>, de l\'élémentaire à la terminale (<em>parcours numérique structuré</em>)',
+    },
+    {
+      text:
+        'Développer des <strong>compétences critiques, créatives et éthiques</strong> dans un monde numérique en évolution constante',
+    },
+    {
+      text:
+        'Permettre aux élèves de <strong>comprendre et maîtriser les outils numériques</strong>, y compris l\'<strong>intelligence artificielle</strong>, pour être <strong>acteurs et non consommateurs</strong>',
+    },
+    {
+      text:
+        'Promouvoir une <strong>culture numérique responsable et citoyenne</strong> : <em>cybersécurité, droit à l\'image, identité numérique, gestion du temps d\'écran</em>',
+    },
+    {
+      text:
+        'Renforcer la <strong>créativité numérique</strong>, l\'<strong>entrepreneuriat</strong> et les <strong>projets interconnectés avec le monde professionnel</strong> et les <strong>enjeux locaux</strong>',
+    },
   ];
-  
+
   const actions = [
-    { text: 'Élaboration d\'un <strong>curriculum numérique spiralaire</strong> de l\'élémentaire à la terminale intégrant le <strong>référentiel PIX</strong> (<em>cycle 3 à terminale</em>)' },
-    { text: 'Introduction progressive du <strong>code</strong> dès le cycle 2, avec consolidation au collège et projets concrets (<em>robotique, applications, jeux éducatifs</em>)' },
-    { text: 'Mise en place d\'un <strong>module IA</strong> au lycée : « <em>comprendre pour maîtriser</em> » (<em>inspiré du guide IA de l\'Éducation nationale</em>)' },
-    { text: 'Déploiement d\'une <strong>éducation au numérique citoyen</strong> (<em>fake news, cyberharcèlement, comportements en ligne, empreinte numérique</em>)' },
-    { text: 'Création d\'un <strong>laboratoire numérique</strong> avec des <strong>projets concrets annuels</strong> portés par les élèves (<em>ex : site écoresponsable, app solidaire…</em>)' },
-    { text: 'Intégration d\'<strong>intervenants extérieurs</strong> (<em>volontaires internationaux, partenaires tech, artistes numériques…</em>)' },
-    { text: 'Élaboration du plan "<strong>Un PC par lycéen</strong>"', link: '/pc-par-lyceen' },
-    { text: '<strong>Amélioration de la connectivité</strong> sur l\'ensemble du site' },
-    { text: 'Mise en place d\'un <strong>plan de renouvellement</strong> pluriannuel du matériel informatique' },
-    { text: 'Organisation de <strong>sorties pédagogiques</strong> et immersions dans des <strong>structures technologiques de référence au Sénégal</strong> (<em>ou à distance</em>)' },
-    { text: 'Développement d\'un <strong>fonds de soutien ou mécénat numérique</strong> pour l\'équipement et la formation' }
+    {
+      text:
+        'Élaboration d\'un <strong>curriculum numérique spiralaire</strong> de l\'élémentaire à la terminale intégrant le <strong>référentiel PIX</strong> (<em>cycle 3 à terminale</em>)',
+    },
+    {
+      text:
+        'Introduction progressive du <strong>code</strong> dès le cycle 2, avec consolidation au collège et projets concrets (<em>robotique, applications, jeux éducatifs</em>)',
+    },
+    {
+      text:
+        'Mise en place d\'un <strong>module IA</strong> au lycée : « <em>comprendre pour maîtriser</em> » (<em>inspiré du guide IA de l\'Éducation nationale</em>)',
+    },
+    {
+      text:
+        'Déploiement d\'une <strong>éducation au numérique citoyen</strong> (<em>fake news, cyberharcèlement, comportements en ligne, empreinte numérique</em>)',
+    },
+    {
+      text:
+        'Création d\'un <strong>laboratoire numérique</strong> avec des <strong>projets concrets annuels</strong> portés par les élèves (<em>ex : site écoresponsable, app solidaire…</em>)',
+    },
+    {
+      text:
+        'Intégration d\'<strong>intervenants extérieurs</strong> (<em>volontaires internationaux, partenaires tech, artistes numériques…</em>)',
+    },
+    {
+      text: 'Élaboration du plan "<strong>Un PC par lycéen</strong>"',
+      link: '/pc-par-lyceen',
+      linkAriaLabel: 'En savoir plus – Un PC par lycéen',
+      linkIcon: Laptop,
+    },
+    {
+      text:
+        '<strong>Amélioration de la connectivité</strong> sur l\'ensemble du site',
+    },
+    {
+      text:
+        'Mise en place d\'un <strong>plan de renouvellement</strong> pluriannuel du matériel informatique',
+    },
+    {
+      text:
+        'Organisation de <strong>sorties pédagogiques</strong> et immersions dans des <strong>structures technologiques de référence au Sénégal</strong> (<em>ou à distance</em>)',
+    },
+    {
+      text:
+        'Développement d\'un <strong>fonds de soutien ou mécénat numérique</strong> pour l\'équipement et la formation',
+    },
   ];
-  
+
   const indicators = [
-    { text: 'Taux d\'élèves <strong>certifiés PIX</strong> par cycle (<em>cycle 4, lycée</em>)' },
-    { text: 'Nombre de <strong>projets numériques interdisciplinaires</strong> par an' },
-    { text: 'Taux d\'élèves ayant participé à un projet <strong>IA, coding</strong> ou <strong>cybersécurité</strong>' },
-    { text: 'Taux de <strong>lycéens équipés en matériel personnel</strong> (<em>objectif 1 PC par lycéen</em>)' },
-    { text: 'Taux de <strong>couverture WiFi / vitesse de connectivité</strong> par zone du lycée' },
-    { text: 'Taux de <strong>satisfaction numérique</strong> dans les enquêtes' },
-    { text: 'Nombre de <strong>partenariats/mécénats</strong> liés au <strong>numérique éducatif</strong>' }
+    {
+      text: 'Taux d\'élèves <strong>certifiés PIX</strong> par cycle (<em>cycle 4, lycée</em>)',
+    },
+    {
+      text: 'Nombre de <strong>projets numériques interdisciplinaires</strong> par an',
+    },
+    {
+      text: 'Taux d\'élèves ayant participé à un projet <strong>IA, coding</strong> ou <strong>cybersécurité</strong>',
+    },
+    {
+      text: 'Taux de <strong>lycéens équipés en matériel personnel</strong> (<em>objectif 1 PC par lycéen</em>)',
+    },
+    {
+      text: 'Taux de <strong>couverture WiFi / vitesse de connectivité</strong> par zone du lycée',
+    },
+    {
+      text: 'Taux de <strong>satisfaction numérique</strong> dans les enquêtes',
+    },
+    {
+      text: 'Nombre de <strong>partenariats/mécénats</strong> liés au <strong>numérique éducatif</strong>',
+    },
   ];
 
   return (
-    <PSDAxeLayout 
+    <PSDAxeLayout
+      axeId={3}
       title="AXE 3 – DIGITAL, NUMÉRIQUE, INNOVATION TECHNOLOGIQUE"
       subtitle="Cultiver la sensibilité, la créativité, la citoyenneté et l'agilité numérique"
+      summary={summary}
       objectifs={objectifs}
       actions={actions}
       indicators={indicators}

--- a/src/components/PSDAxe4.tsx
+++ b/src/components/PSDAxe4.tsx
@@ -1,42 +1,151 @@
-
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { ExternalLink } from 'lucide-react';
+import {
+  Compass,
+  HeartHandshake,
+  RefreshCcw,
+  Sparkles,
+  UsersRound,
+  Wallet,
+} from 'lucide-react';
 import PSDAxeLayout from './PSDAxeLayout';
 
 const PSDAxe4 = () => {
+  const summary = {
+    objectives: [
+      { icon: '🎓', label: 'Réussites multiples' },
+      { icon: '💬', label: 'Soft skills & confiance' },
+      { icon: '🧭', label: 'Orientation éclairée' },
+    ],
+    actions: [
+      {
+        label: 'Modules soft skills',
+        icon: Sparkles,
+        iconClassName: 'text-indigo-600',
+      },
+      {
+        label: 'Valoriser l\'erreur',
+        icon: RefreshCcw,
+        iconClassName: 'text-amber-600',
+      },
+      {
+        label: 'Parcours citoyen',
+        icon: HeartHandshake,
+        iconClassName: 'text-emerald-600',
+      },
+      {
+        label: 'Éducation financière',
+        icon: Wallet,
+        iconClassName: 'text-rose-600',
+      },
+      {
+        label: 'Réseau alumni & mentorat',
+        icon: UsersRound,
+        iconClassName: 'text-indigo-700',
+      },
+      {
+        label: 'Soutien à l\'orientation',
+        icon: Compass,
+        iconClassName: 'text-blue-600',
+      },
+    ],
+    indicators: [
+      { label: 'Participation clubs & projets', value: '≥ 80 %' },
+      { label: 'Capacité de rebond déclarée', value: '+15 pts' },
+      { label: 'Alumni mobilisés/an', value: '≥ 30 dès 2027' },
+    ],
+  };
+
   const objectifs = [
-    { text: 'Maintenir le <strong>niveau d\'excellence</strong> et poursuivre la montée en puissance de la <strong>réussite aux examens</strong>' },
-    { text: 'Développer les <strong>compétences psychosociales et humaines</strong> des élèves (<strong>soft skills</strong>) : prise de parole, coopération, gestion de l\'échec, résilience, esprit critique, engagement citoyen' },
-    { text: 'Encourager l\'<strong>autonomie</strong>, la <strong>persévérance</strong> et la capacité à s\'orienter de manière éclairée' },
-    { text: 'Valoriser toutes les formes de <strong>réussite</strong> : scolaire, artistique, humaine, citoyenne, collective' },
-    { text: 'Faire du <strong>LFJP une école de la confiance et du rebond</strong> : apprendre à apprendre, à s\'adapter, à se relever' },
-    { text: 'Renforcer les liens avec les <strong>anciens élèves (alumni)</strong> et créer une <strong>communauté intergénérationnelle</strong> inspirante' },
-    { text: 'Impliquer pleinement les <strong>familles</strong> dans les parcours de réussite des élèves' }
+    {
+      text:
+        'Maintenir le <strong>niveau d\'excellence</strong> et poursuivre la montée en puissance de la <strong>réussite aux examens</strong>',
+    },
+    {
+      text:
+        'Développer les <strong>compétences psychosociales et humaines</strong> des élèves (<strong>soft skills</strong>) : prise de parole, coopération, gestion de l\'échec, résilience, esprit critique, engagement citoyen',
+    },
+    {
+      text:
+        'Encourager l\'<strong>autonomie</strong>, la <strong>persévérance</strong> et la capacité à s\'orienter de manière éclairée',
+    },
+    {
+      text:
+        'Valoriser toutes les formes de <strong>réussite</strong> : scolaire, artistique, humaine, citoyenne, collective',
+    },
+    {
+      text:
+        'Faire du <strong>LFJP une école de la confiance et du rebond</strong> : apprendre à apprendre, à s\'adapter, à se relever',
+    },
+    {
+      text:
+        'Renforcer les liens avec les <strong>anciens élèves (alumni)</strong> et créer une <strong>communauté intergénérationnelle</strong> inspirante',
+    },
+    {
+      text:
+        'Impliquer pleinement les <strong>familles</strong> dans les parcours de réussite des élèves',
+    },
   ];
-  
+
   const actions = [
-    { text: '<strong>Développement des compétences transversales (soft skills)</strong> :<br/>• Modules sur l\'<strong>expression orale</strong>, l\'<strong>estime de soi</strong>, la <strong>gestion du stress</strong>, la <strong>pensée critique</strong><br/>• <strong>Clubs théâtre, débat, journalisme, leadership</strong><br/>• Pratique de l\'<strong>éloquence au collège et au lycée</strong>' },
-    { text: '<strong>Valorisation de l\'erreur et de la persévérance</strong> :<br/>• <strong>Pédagogies explicites</strong> sur l\'erreur constructive<br/>• <strong>Interventions d\'anciens élèves</strong> autour de leurs parcours<br/>• Programme « <strong>Cultiver l\'audace</strong> » valorisant les initiatives étudiantes' },
-    { text: '<strong>Parcours de la Réussite citoyenne</strong> :<br/>• <strong>Projets solidaires et participatifs</strong> (ex. budgets participatifs)<br/>• Modules de formation à l\'<strong>engagement citoyen</strong>' },
-    { text: '<strong>Éducation financière et à la vie autonome</strong> :<br/>• Ateliers sur la <strong>gestion budgétaire</strong> et la <strong>vie étudiante post-bac</strong><br/>• Interventions de <strong>professionnels et parents volontaires</strong>' },
-    { text: '<strong>Réseau d\'alumni et mentorat</strong> :<br/>• Constitution d\'une <strong>base de données d\'anciens élèves</strong><br/>• <strong>Mentorat lycéens / alumni</strong><br/>• Rubrique « <strong>Les Oiseaux de Passage</strong> » valorisée dans la communication interne' },
-    { text: '<strong>Soutien à l\'orientation</strong> :<br/>• <strong>Accompagnement personnalisé</strong> dans le cadre du Parcours Avenir<br/>• <strong>Stages, forums métiers, espace orientation</strong>' }
+    {
+      text:
+        '<strong>Développement des compétences transversales (soft skills)</strong> :<br/>• Modules sur l\'<strong>expression orale</strong>, l\'<strong>estime de soi</strong>, la <strong>gestion du stress</strong>, la <strong>pensée critique</strong><br/>• <strong>Clubs théâtre, débat, journalisme, leadership</strong><br/>• Pratique de l\'<strong>éloquence au collège et au lycée</strong>',
+    },
+    {
+      text:
+        '<strong>Valorisation de l\'erreur et de la persévérance</strong> :<br/>• <strong>Pédagogies explicites</strong> sur l\'erreur constructive<br/>• <strong>Interventions d\'anciens élèves</strong> autour de leurs parcours<br/>• Programme « <strong>Cultiver l\'audace</strong> » valorisant les initiatives étudiantes',
+    },
+    {
+      text:
+        '<strong>Parcours de la Réussite citoyenne</strong> :<br/>• <strong>Projets solidaires et participatifs</strong> (ex. budgets participatifs)<br/>• Modules de formation à l\'<strong>engagement citoyen</strong>',
+    },
+    {
+      text:
+        '<strong>Éducation financière et à la vie autonome</strong> :<br/>• Ateliers sur la <strong>gestion budgétaire</strong> et la <strong>vie étudiante post-bac</strong><br/>• Interventions de <strong>professionnels et parents volontaires</strong>',
+    },
+    {
+      text:
+        '<strong>Réseau d\'alumni et mentorat</strong> :<br/>• Constitution d\'une <strong>base de données d\'anciens élèves</strong><br/>• <strong>Mentorat lycéens / alumni</strong><br/>• Rubrique « <strong>Les Oiseaux de Passage</strong> » valorisée dans la communication interne',
+    },
+    {
+      text:
+        '<strong>Soutien à l\'orientation</strong> :<br/>• <strong>Accompagnement personnalisé</strong> dans le cadre du Parcours Avenir<br/>• <strong>Stages, forums métiers, espace orientation</strong>',
+    },
   ];
-  
+
   const indicators = [
-    { text: '<strong>% des élèves participant</strong> à un <strong>club citoyen, débat, théâtre, journal</strong> (≥ <strong>80 % collège/lycée</strong>)' },
-    { text: '<strong>% d\'élèves déclarant</strong> « <strong>savoir rebondir après un échec</strong> » (via enquête climat) (<strong>+15 pts</strong> par rapport à 2024)' },
-    { text: '<strong>% d\'élèves impliqués</strong> dans un <strong>projet citoyen ou solidaire</strong> (<strong>100 % cycle 4 et lycée</strong>)' },
-    { text: '<strong>% d\'élèves accompagnés individuellement</strong> en terminale (<strong>100 %</strong>)' },
-    { text: '<strong>Nombre d\'alumni mobilisés</strong> par an (≥ <strong>30 dès 2027</strong>)' },
-    { text: '<strong>Taux de satisfaction</strong> sur l\'accompagnement à la réussite (enquêtes) (≥ <strong>90 %</strong>)' }
+    {
+      text:
+        '<strong>% des élèves participant</strong> à un <strong>club citoyen, débat, théâtre, journal</strong> (≥ <strong>80 % collège/lycée</strong>)',
+    },
+    {
+      text:
+        '<strong>% d\'élèves déclarant</strong> « <strong>savoir rebondir après un échec</strong> » (via enquête climat) (<strong>+15 pts</strong> par rapport à 2024)',
+    },
+    {
+      text:
+        '<strong>% d\'élèves impliqués</strong> dans un <strong>projet citoyen ou solidaire</strong> (<strong>100 % cycle 4 et lycée</strong>)',
+    },
+    {
+      text:
+        '<strong>% d\'élèves accompagnés individuellement</strong> en terminale (<strong>100 %</strong>)',
+    },
+    {
+      text:
+        '<strong>Nombre d\'alumni mobilisés</strong> par an (≥ <strong>30 dès 2027</strong>)',
+    },
+    {
+      text:
+        '<strong>Taux de satisfaction</strong> sur l\'accompagnement à la réussite (enquêtes) (≥ <strong>90 %</strong>)',
+    },
   ];
 
   return (
-    <PSDAxeLayout 
+    <PSDAxeLayout
+      axeId={4}
       title="AXE 4 – FAÇONNER LES RÉUSSITES"
       subtitle="Accompagner chaque élève dans son développement personnel, scolaire et citoyen, pour une réussite complète, durable et équilibrée"
+      summary={summary}
       objectifs={objectifs}
       actions={actions}
       indicators={indicators}

--- a/src/components/PSDAxeLayout.tsx
+++ b/src/components/PSDAxeLayout.tsx
@@ -1,107 +1,349 @@
-
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { ShieldCheck, Utensils } from 'lucide-react';
+import {
+  ArrowUpRightSquare,
+  BarChart3,
+  ListChecks,
+  Target,
+  type LucideIcon,
+} from 'lucide-react';
 
-interface ObjectifItem {
-  text: string;
+const AXE_COLORS: Record<number, {
+  heading: string;
+  ring: string;
+  chipBg: string;
+  chipText: string;
+  icon: string;
+  iconBg: string;
+  indicatorValue: string;
+  buttonFocus: string;
+}> = {
+  1: {
+    heading: 'text-blue-900',
+    ring: 'ring-blue-200',
+    chipBg: 'bg-blue-50',
+    chipText: 'text-blue-800',
+    icon: 'text-blue-600',
+    iconBg: 'bg-blue-100',
+    indicatorValue: 'text-blue-800',
+    buttonFocus: 'focus-visible:ring-blue-600',
+  },
+  2: {
+    heading: 'text-emerald-900',
+    ring: 'ring-emerald-200',
+    chipBg: 'bg-emerald-50',
+    chipText: 'text-emerald-800',
+    icon: 'text-emerald-600',
+    iconBg: 'bg-emerald-100',
+    indicatorValue: 'text-emerald-800',
+    buttonFocus: 'focus-visible:ring-emerald-600',
+  },
+  3: {
+    heading: 'text-amber-900',
+    ring: 'ring-amber-200',
+    chipBg: 'bg-amber-50',
+    chipText: 'text-amber-900',
+    icon: 'text-amber-600',
+    iconBg: 'bg-amber-100',
+    indicatorValue: 'text-amber-900',
+    buttonFocus: 'focus-visible:ring-amber-600',
+  },
+  4: {
+    heading: 'text-indigo-900',
+    ring: 'ring-indigo-200',
+    chipBg: 'bg-indigo-50',
+    chipText: 'text-indigo-900',
+    icon: 'text-indigo-600',
+    iconBg: 'bg-indigo-100',
+    indicatorValue: 'text-indigo-900',
+    buttonFocus: 'focus-visible:ring-indigo-600',
+  },
+  5: {
+    heading: 'text-cyan-900',
+    ring: 'ring-cyan-200',
+    chipBg: 'bg-cyan-50',
+    chipText: 'text-cyan-800',
+    icon: 'text-cyan-600',
+    iconBg: 'bg-cyan-100',
+    indicatorValue: 'text-cyan-900',
+    buttonFocus: 'focus-visible:ring-cyan-600',
+  },
+};
+
+interface SummaryChip {
+  label: string;
+  icon?: React.ReactNode;
 }
 
-interface ActionItem {
+interface SummaryAction {
+  label: string;
+  icon: LucideIcon;
+  iconClassName?: string;
+  link?: string;
+  linkLabel?: string;
+  linkAriaLabel?: string;
+}
+
+interface SummaryKpi {
+  label: string;
+  value: string;
+}
+
+interface DetailedActionItem {
   text: string;
   link?: string;
+  linkLabel?: string;
+  linkAriaLabel?: string;
+  linkIcon?: LucideIcon;
 }
 
-interface IndicatorItem {
+interface DetailItem {
   text: string;
 }
 
 interface PSDAxeLayoutProps {
+  axeId: 1 | 2 | 3 | 4 | 5;
   title: string;
   subtitle: string;
-  objectifs: ObjectifItem[];
-  actions: ActionItem[];
-  indicators: IndicatorItem[];
+  summary: {
+    objectives: SummaryChip[];
+    actions: SummaryAction[];
+    indicators: SummaryKpi[];
+  };
+  objectifs: DetailItem[];
+  actions: DetailedActionItem[];
+  indicators: DetailItem[];
 }
 
 const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
+  axeId,
   title,
   subtitle,
+  summary,
   objectifs,
   actions,
-  indicators
+  indicators,
 }) => {
+  const palette = AXE_COLORS[axeId];
+
   return (
     <div>
-      <h3 className="text-xl font-playfair font-bold text-french-blue mb-4">
-        {title}
-      </h3>
-      <p className="text-lg font-medium font-raleway text-gray-800 mb-4">
-        {subtitle}
-      </p>
-      
-      <div className="mt-6 space-y-4">
-        <div>
-          <h4 className="font-semibold text-gray-900 mb-2">Objectifs</h4>
-          <ul className="list-disc pl-5 space-y-1 text-gray-700 font-raleway">
+      <header className="mb-8">
+        <p className="text-sm text-slate-500">Plan stratégique de développement</p>
+        <h3
+          className={`text-2xl sm:text-3xl font-bold ${palette?.heading ?? 'text-slate-900'}`}
+        >
+          {title}
+        </h3>
+        <p className="mt-2 text-slate-600">{subtitle}</p>
+      </header>
+
+      <section className="grid gap-6 xl:grid-cols-3">
+        <article
+          className={`bg-white rounded-2xl shadow-sm ring-1 p-6 flex flex-col ${
+            palette?.ring ?? 'ring-slate-200'
+          }`}
+          data-axe={axeId}
+        >
+          <div className="flex items-center gap-3 mb-4">
+            <span
+              className={`flex h-10 w-10 items-center justify-center rounded-full ${
+                palette?.iconBg ?? 'bg-slate-100'
+              } ${palette?.icon ?? 'text-slate-600'}`}
+            >
+              <Target className="h-6 w-6" aria-hidden="true" />
+            </span>
+            <h4 className="text-xl font-semibold text-slate-900">Objectifs</h4>
+          </div>
+          <ul className="grid gap-2">
+            {summary.objectives.map((chip) => (
+              <li key={chip.label}>
+                <span
+                  className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm font-medium ${
+                    palette?.chipBg ?? 'bg-slate-100'
+                  } ${palette?.chipText ?? 'text-slate-800'}`}
+                >
+                  {chip.icon ? (
+                    <span aria-hidden="true">{chip.icon}</span>
+                  ) : null}
+                  <span>{chip.label}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-5">
+            <a
+              href="#details-objectifs"
+              className={`inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-800 transition hover:bg-slate-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 ${
+                palette?.buttonFocus ?? 'focus-visible:ring-slate-600'
+              }`}
+              aria-label="Voir le détail des objectifs"
+            >
+              <ArrowUpRightSquare className="h-4 w-4" aria-hidden="true" />
+              <span>Voir le détail</span>
+            </a>
+          </div>
+        </article>
+
+        <article
+          className={`bg-white rounded-2xl shadow-sm ring-1 p-6 flex flex-col ${
+            palette?.ring ?? 'ring-slate-200'
+          }`}
+          data-axe={axeId}
+        >
+          <div className="flex items-center gap-3 mb-4">
+            <span
+              className={`flex h-10 w-10 items-center justify-center rounded-full ${
+                palette?.iconBg ?? 'bg-slate-100'
+              } ${palette?.icon ?? 'text-slate-600'}`}
+            >
+              <ListChecks className="h-6 w-6" aria-hidden="true" />
+            </span>
+            <h4 className="text-xl font-semibold text-slate-900">Actions prioritaires</h4>
+          </div>
+          <ul className="grid gap-3 sm:grid-cols-2">
+            {summary.actions.map((action) => {
+              const TileIcon = action.icon;
+              return (
+                <li
+                  key={action.label}
+                  className="group flex items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50 p-3 transition hover:bg-white hover:shadow-sm"
+                >
+                  <div className="flex items-center gap-3">
+                    <TileIcon
+                      className={`h-5 w-5 ${action.iconClassName ?? palette?.icon ?? 'text-slate-600'}`}
+                      aria-hidden="true"
+                    />
+                    <span className="text-sm font-medium text-slate-800">{action.label}</span>
+                  </div>
+                  {action.link ? (
+                    <Link
+                      to={action.link}
+                      className={`inline-flex items-center gap-2 rounded-lg border border-slate-300 px-2.5 py-1.5 text-xs font-medium text-slate-800 transition hover:shadow-sm hover:underline focus:outline-none focus-visible:ring-2 ${
+                        palette?.buttonFocus ?? 'focus-visible:ring-slate-600'
+                      }`}
+                      aria-label={action.linkAriaLabel ?? action.label}
+                    >
+                      <ArrowUpRightSquare className="h-4 w-4" aria-hidden="true" />
+                      <span>{action.linkLabel ?? 'En savoir plus'}</span>
+                    </Link>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </article>
+
+        <article
+          className={`bg-white rounded-2xl shadow-sm ring-1 p-6 flex flex-col ${
+            palette?.ring ?? 'ring-slate-200'
+          }`}
+          data-axe={axeId}
+          aria-label="Indicateurs clés"
+        >
+          <div className="flex items-center gap-3 mb-4">
+            <span
+              className={`flex h-10 w-10 items-center justify-center rounded-full ${
+                palette?.iconBg ?? 'bg-slate-100'
+              } ${palette?.icon ?? 'text-slate-600'}`}
+            >
+              <BarChart3 className="h-6 w-6" aria-hidden="true" />
+            </span>
+            <h4 className="text-xl font-semibold text-slate-900">Indicateurs</h4>
+          </div>
+          <div className="grid gap-4">
+            {summary.indicators.map((kpi) => (
+              <div
+                key={kpi.label}
+                className={`rounded-2xl bg-white p-5 shadow-sm ring-1 ${
+                  palette?.ring ?? 'ring-slate-200'
+                }`}
+              >
+                <p className="text-sm text-slate-500">{kpi.label}</p>
+                <p
+                  className={`mt-1 text-3xl font-semibold ${
+                    palette?.indicatorValue ?? 'text-slate-900'
+                  }`}
+                >
+                  {kpi.value}
+                </p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-5">
+            <a
+              href="#details-indicateurs"
+              className={`inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-800 transition hover:bg-slate-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 ${
+                palette?.buttonFocus ?? 'focus-visible:ring-slate-600'
+              }`}
+              aria-label="Voir le détail des indicateurs"
+            >
+              <ArrowUpRightSquare className="h-4 w-4" aria-hidden="true" />
+              <span>Voir le détail</span>
+            </a>
+          </div>
+        </article>
+      </section>
+
+      <section className="mt-12 space-y-8">
+        <div
+          id="details-objectifs"
+          className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <h4 className="mb-3 text-lg font-semibold text-slate-900">Objectifs détaillés</h4>
+          <ul className="list-disc space-y-2 pl-5 text-gray-700 font-raleway">
             {objectifs.map((item, index) => (
               <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
             ))}
           </ul>
         </div>
-        
-        <div>
-          <h4 className="font-semibold text-gray-900 mb-2">Actions prioritaires</h4>
-          <ul className="list-disc pl-5 space-y-1 text-gray-700 font-raleway">
-            {actions.map((item, index) => {
-              const hasLink = Boolean(item.link);
-              const textContent = item.text.toLowerCase();
-              const iconType = textContent.includes('harcèlement')
-                ? 'harcelement'
-                : textContent.includes('restauration')
-                ? 'restauration'
-                : null;
-              const IconComponent = iconType === 'harcelement' ? ShieldCheck : iconType === 'restauration' ? Utensils : null;
-              const ariaLabelSuffix = iconType === 'harcelement'
-                ? 'Prévention du harcèlement'
-                : iconType === 'restauration'
-                ? 'Restauration scolaire'
-                : '';
 
-              if (!hasLink || !IconComponent || !item.link) {
+        <div
+          id="details-actions"
+          className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <h4 className="mb-3 text-lg font-semibold text-slate-900">Actions prioritaires détaillées</h4>
+          <ul className="list-disc space-y-3 pl-5 text-gray-700 font-raleway">
+            {actions.map((item, index) => {
+              if (!item.link) {
                 return (
-                  <li key={index} className="list-item">
-                    <span dangerouslySetInnerHTML={{ __html: item.text }}></span>
-                  </li>
+                  <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
                 );
               }
 
+              const LinkIcon = item.linkIcon ?? ArrowUpRightSquare;
+
               return (
-                <li key={index} className="action-item">
-                  <span className="action-text" dangerouslySetInnerHTML={{ __html: item.text }}></span>
+                <li key={index} className="flex flex-wrap items-center gap-2">
+                  <span dangerouslySetInnerHTML={{ __html: item.text }}></span>
                   <Link
                     to={item.link}
-                    className="btn-link"
-                    aria-label={`En savoir plus – ${ariaLabelSuffix}`}
+                    className={`inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 ${
+                      palette?.buttonFocus ?? 'focus-visible:ring-slate-600'
+                    }`}
+                    aria-label={item.linkAriaLabel ?? item.linkLabel ?? 'En savoir plus'}
                   >
-                    <IconComponent className="icon" size={18} aria-hidden="true" />
-                    <span>En savoir plus</span>
+                    <LinkIcon className="h-4 w-4" aria-hidden="true" />
+                    <span>{item.linkLabel ?? 'En savoir plus'}</span>
                   </Link>
                 </li>
               );
             })}
           </ul>
         </div>
-        
-        <div>
-          <h4 className="font-semibold text-gray-900 mb-2">Indicateurs</h4>
-          <ul className="list-disc pl-5 space-y-1 text-gray-700 font-raleway">
+
+        <div
+          id="details-indicateurs"
+          className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <h4 className="mb-3 text-lg font-semibold text-slate-900">Indicateurs détaillés</h4>
+          <ul className="list-disc space-y-2 pl-5 text-gray-700 font-raleway">
             {indicators.map((item, index) => (
               <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
             ))}
           </ul>
         </div>
-      </div>
+      </section>
     </div>
   );
 };

--- a/src/components/PSDAxeTransversal.tsx
+++ b/src/components/PSDAxeTransversal.tsx
@@ -1,35 +1,90 @@
-
 import React from 'react';
+import {
+  Calculator,
+  Megaphone,
+  MessageCircle,
+  Presentation,
+  Wrench,
+} from 'lucide-react';
 import PSDAxeLayout from './PSDAxeLayout';
 
 const PSDAxeTransversal = () => {
+  const summary = {
+    objectives: [
+      { icon: '📊', label: 'Pilotage agile' },
+      { icon: '🤝', label: 'Engagement collectif' },
+      { icon: '🏗️', label: 'Maintenance durable' },
+    ],
+    actions: [
+      {
+        label: 'Simulation financière annuelle',
+        icon: Calculator,
+        iconClassName: 'text-cyan-700',
+      },
+      {
+        label: 'Tableaux de bord partagés',
+        icon: Presentation,
+        iconClassName: 'text-sky-600',
+      },
+      {
+        label: 'Communication continue',
+        icon: Megaphone,
+        iconClassName: 'text-cyan-600',
+      },
+      {
+        label: 'Espaces d\'échange',
+        icon: MessageCircle,
+        iconClassName: 'text-cyan-500',
+      },
+      {
+        label: 'Plan maintenance stratégique',
+        icon: Wrench,
+        iconClassName: 'text-emerald-600',
+        link: '/plan-maintenance-strategique',
+        linkAriaLabel: 'En savoir plus – Plan de maintenance stratégique',
+      },
+    ],
+    indicators: [
+      { label: 'Pilotage du plan', value: 'Bilans semestriels' },
+      { label: 'Rencontres communautaires', value: '≥ 4/an' },
+      { label: 'Plan maintenance', value: 'Diffusé & suivi' },
+    ],
+  };
+
   const objectifs = [
     { text: 'Garantir une mise en œuvre efficace, évaluée et communiquée du plan' },
     { text: 'Renforcer la cohésion des équipes et la solidarité communautaire' },
     { text: 'Utiliser les enquêtes ELCS comme référence pour piloter le PSD' },
     { text: 'Plan d\'entretien de l\'immobilier' },
-    { text: 'Plan d\'entretien et de renouvellement du mobilier' }
+    { text: 'Plan d\'entretien et de renouvellement du mobilier' },
   ];
-  
+
   const actions = [
     { text: 'Simulation financière annuelle présentée en conseil d\'établissement' },
     { text: 'Tableaux de bord thématiques et bilans de mi-parcours' },
     { text: 'Développement de supports de communication' },
     { text: 'Organisation d\'espaces d\'échange pour renforcer le sentiment d\'appartenance' },
-    { text: 'Plan de maintenance stratégique', link: '/plan-maintenance-strategique' }
+    {
+      text: 'Plan de maintenance stratégique',
+      link: '/plan-maintenance-strategique',
+      linkAriaLabel: 'En savoir plus – Plan de maintenance stratégique',
+      linkIcon: Wrench,
+    },
   ];
-  
+
   const indicators = [
     { text: 'Taux d\'atteinte des objectifs du plan par axe' },
     { text: 'Participation aux instances de pilotage' },
     { text: 'Indice de sentiment d\'appartenance' },
-    { text: 'Évolution des indicateurs issus des enquêtes ELCS' }
+    { text: 'Évolution des indicateurs issus des enquêtes ELCS' },
   ];
 
   return (
-    <PSDAxeLayout 
+    <PSDAxeLayout
+      axeId={5}
       title="AXE TRANSVERSAL – PILOTAGE, GOUVERNANCE ET VIABILITÉ"
-      subtitle=""
+      subtitle="" 
+      summary={summary}
       objectifs={objectifs}
       actions={actions}
       indicators={indicators}


### PR DESCRIPTION
## Summary
- rebuild the PSD axe layout into a reusable card design with per-axe color palettes and summary CTAs
- migrate Axes 1 to 4 and the transversal axis to the new template with tailored objectives, action tiles, and KPI chips
- align action links and indicators with the new summary/detail structure for consistent navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d03ec7ef488331b4175565ffa563e2