### PR TITLE
Enhance PSD axe layout and resolve axe 2 content

### DIFF
--- a/src/components/PSDAxe2.tsx
+++ b/src/components/PSDAxe2.tsx
@@ -1,35 +1,140 @@
 import React from 'react';
+import {
+  CalendarHeart,
+  Globe2,
+  Handshake,
+  Languages,
+  Plane,
+  Sprout,
+} from 'lucide-react';
 import PSDAxeLayout from './PSDAxeLayout';
 
 const PSDAxe2 = () => {
+  const summary = {
+    objectives: [
+      { icon: '🗣️', label: 'Plurilinguisme valorisé' },
+      { icon: '🌍', label: 'Ouverture internationale' },
+      { icon: '🤝', label: 'Dialogue interculturel' },
+    ],
+    actions: [
+      {
+        label: 'Plan Section internationale & BFI',
+        icon: Globe2,
+        iconClassName: 'text-emerald-600',
+        link: '/section-internationale-bfi',
+        linkAriaLabel: 'En savoir plus – Section internationale et BFI',
+      },
+      {
+        label: 'Voyages et jumelages',
+        icon: Plane,
+        iconClassName: 'text-sky-600',
+      },
+      {
+        label: 'Semaine des cultures',
+        icon: CalendarHeart,
+        iconClassName: 'text-amber-600',
+      },
+      {
+        label: 'Médiation interculturelle',
+        icon: Handshake,
+        iconClassName: 'text-rose-600',
+      },
+      {
+        label: 'Familles & langues du LFJP',
+        icon: Languages,
+        iconClassName: 'text-indigo-600',
+      },
+      {
+        label: 'Partenariats E³D',
+        icon: Sprout,
+        iconClassName: 'text-emerald-700',
+      },
+    ],
+    indicators: [
+      { label: 'Sections & certifications actives', value: 'SI & BFI 2026-2033' },
+      { label: 'Partenariats locaux et internationaux', value: '≥ 5 actifs' },
+      { label: 'Événements interculturels', value: 'Semaine annuelle' },
+    ],
+  };
+
   const objectifs = [
-    { text: 'Développer un environnement scolaire où la <strong>diversité des langues, cultures et nationalités</strong> présentes au LFJP devient un <strong>atout éducatif et citoyen</strong>.' },
-    { text: 'Renforcer la <strong>maîtrise des langues vivantes étrangères</strong> et du <strong>français langue de scolarisation</strong>, conformément aux orientations de l\'Éducation nationale et de l\'AEFE.' },
-    { text: 'Former des élèves capables de comprendre et d\'évoluer dans un <strong>monde multipolaire</strong>, ouverts à la <strong>pluralité des cultures, religions et visions du monde</strong>.' },
-    { text: 'Prévenir les <strong>chocs culturels</strong> en dotant les élèves de repères sociologiques et psychologiques favorisant la <strong>tolérance, le dialogue et l\'intercompréhension</strong>.' },
-    { text: 'Consolider les <strong>parcours éducatifs</strong> (Parcours citoyen, Parcours Avenir, PEAC) par des <strong>expériences interculturelles et internationales</strong>.' }
+    {
+      text:
+        'Développer un environnement scolaire où la <strong>diversité des langues, cultures et nationalités</strong> présentes au LFJP devient un <strong>atout éducatif et citoyen</strong>.',
+    },
+    {
+      text:
+        'Renforcer la <strong>maîtrise des langues vivantes étrangères</strong> et du <strong>français langue de scolarisation</strong>, conformément aux orientations de l\'Éducation nationale et de l\'AEFE.',
+    },
+    {
+      text:
+        'Former des élèves capables de comprendre et d\'évoluer dans un <strong>monde multipolaire</strong>, ouverts à la <strong>pluralité des cultures, religions et visions du monde</strong>.',
+    },
+    {
+      text:
+        'Prévenir les <strong>chocs culturels</strong> en dotant les élèves de repères sociologiques et psychologiques favorisant la <strong>tolérance, le dialogue et l\'intercompréhension</strong>.',
+    },
+    {
+      text:
+        'Consolider les <strong>parcours éducatifs</strong> (Parcours citoyen, Parcours Avenir, PEAC) par des <strong>expériences interculturelles et internationales</strong>.',
+    },
   ];
-  
+
   const actions = [
-    { text: '<strong>Sections et certifications internationales</strong> :<br/>• <strong>Déploiement du plan « Section Internationale et BFI »</strong> (2026-2033) <a href="/section-internationale-bfi" class="inline-flex items-center text-french-blue hover:text-french-blue/80"><svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg></a><br/>• Recrutement et formation d\'<strong>enseignants locuteurs natifs</strong> ou hautement qualifiés (niveau <strong>C2 CECRL</strong>) pour les disciplines non linguistiques et littéraires.' },
-    { text: '<strong>Ouverture internationale</strong> :<br/>• Développer les <strong>voyages scolaires thématiques</strong> (culturels, scientifiques, sportifs) en tant que leviers pédagogiques d\'ouverture au monde.<br/>• Explorer les <strong>jumelages avec d\'autres lycées français</strong> de l\'étranger et les partenariats <strong>Erasmus+/AEFE</strong>.' },
-    { text: '<strong>Ouverture locale</strong> :<br/>• Renforcer les <strong>coopérations avec les écoles et établissements voisins</strong> (activités conjointes, projets citoyens, actions artistiques et sportives).<br/>• Organiser une « <strong>Semaine des cultures</strong> » annuelle, durant laquelle les élèves présentent leurs langues, traditions et patrimoines culturels.' },
-    { text: '<strong>Vie scolaire et climat interculturel</strong> :<br/>• Favoriser la <strong>médiation et la prévention</strong> des incompréhensions interculturelles. <span class="cta-inline"><a href="/mediation-entre-pairs">→ Découvrir la médiation entre pairs</a></span><br/>• Intégrer les <strong>langues et cultures des familles</strong> dans la vie de l\'établissement (journées thématiques, interventions de parents).' },
-    { text: '<strong>Politique E3D</strong> avec maintien des <strong>17 objectifs de développement durable</strong>, demande de <strong>labellisation niveau 3</strong>, et présence d\'<strong>éco-délégués</strong>' }
+    {
+      text:
+        '<strong>Sections et certifications internationales</strong> :<br/>• <strong>Déploiement du plan « Section Internationale et BFI »</strong> (2026-2033)<br/>• Recrutement et formation d\'<strong>enseignants locuteurs natifs</strong> ou hautement qualifiés (niveau <strong>C2 CECRL</strong>) pour les disciplines non linguistiques et littéraires.',
+      link: '/section-internationale-bfi',
+      linkAriaLabel: 'En savoir plus – Section internationale et BFI',
+      linkIcon: Globe2,
+    },
+    {
+      text:
+        '<strong>Ouverture internationale</strong> :<br/>• Développer les <strong>voyages scolaires thématiques</strong> (culturels, scientifiques, sportifs) en tant que leviers pédagogiques d\'ouverture au monde.<br/>• Explorer les <strong>jumelages avec d\'autres lycées français</strong> de l\'étranger et les partenariats <strong>Erasmus+/AEFE</strong>.',
+    },
+    {
+      text:
+        '<strong>Ouverture locale</strong> :<br/>• Renforcer les <strong>coopérations avec les écoles et établissements voisins</strong> (activités conjointes, projets citoyens, actions artistiques et sportives).<br/>• Organiser une « <strong>Semaine des cultures</strong> » annuelle, durant laquelle les élèves présentent leurs langues, traditions et patrimoines culturels.',
+    },
+    {
+      text:
+        '<strong>Vie scolaire et climat interculturel</strong> :<br/>• Favoriser la <strong>médiation et la prévention</strong> des incompréhensions interculturelles.<br/>• Intégrer les <strong>langues et cultures des familles</strong> dans la vie de l\'établissement (journées thématiques, interventions de parents). <span class="cta-inline"><a href="/mediation-entre-pairs">→ Découvrir la médiation entre pairs</a></span>',
+    },
+    {
+      text:
+        '<strong>Politique E3D</strong> avec maintien des <strong>17 objectifs de développement durable</strong>, demande de <strong>labellisation niveau 3</strong>, et présence d\'<strong>éco-délégués</strong>.',
+    },
   ];
-  
+
   const indicators = [
-    { text: 'Taux d\'élèves engagés dans des <strong>sections et certifications internationales</strong> (SI, BFI).' },
-    { text: 'Pourcentage d\'<strong>enseignants de LV et DNL locuteurs natifs</strong> ou certifiés C2.' },
-    { text: 'Nombre de <strong>partenariats locaux et internationaux</strong> actifs.' },
-    { text: 'Taux de satisfaction des élèves et familles concernant l\'<strong>ouverture culturelle et linguistique</strong> (enquêtes climats scolaires).' },
-    { text: 'Participation annuelle des élèves aux projets de la « <strong>Semaine des cultures</strong> » et aux <strong>jumelages</strong>.' }
+    {
+      text:
+        'Taux d\'élèves engagés dans des <strong>sections et certifications internationales</strong> (SI, BFI).',
+    },
+    {
+      text:
+        'Pourcentage d\'<strong>enseignants de LV et DNL locuteurs natifs</strong> ou certifiés C2.',
+    },
+    {
+      text:
+        'Nombre de <strong>partenariats locaux et internationaux</strong> actifs.',
+    },
+    {
+      text:
+        'Taux de satisfaction des élèves et familles concernant l\'<strong>ouverture culturelle et linguistique</strong> (enquêtes climats scolaires).',
+    },
+    {
+      text:
+        'Participation annuelle des élèves aux projets de la « <strong>Semaine des cultures</strong> » et aux <strong>jumelages</strong>.',
+    },
   ];
 
   return (
-    <PSDAxeLayout 
+    <PSDAxeLayout
+      axeId={2}
       title="AXE 2 – PLURILINGUISME, MULTICULTURALITÉ, OUVERTURE INTERNATIONALE ET LOCALE"
       subtitle="Cultiver la diversité linguistique et culturelle comme levier d'apprentissage et d'ouverture au monde"
+      summary={summary}
       objectifs={objectifs}
       actions={actions}
       indicators={indicators}

--- a/src/components/PSDAxe4.tsx
+++ b/src/components/PSDAxe4.tsx
@@ -1,7 +1,5 @@
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { ExternalLink } from 'lucide-react';
 import PSDAxeLayout from './PSDAxeLayout';
 
 const PSDAxe4 = () => {

--- a/src/components/PSDAxeLayout.tsx
+++ b/src/components/PSDAxeLayout.tsx
@@ -1,7 +1,7 @@
-
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { ShieldCheck, Utensils } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { ArrowRight, BarChart3, ListChecks, Target } from 'lucide-react';
 
 interface ObjectifItem {
   text: string;
@@ -10,81 +10,220 @@ interface ObjectifItem {
 interface ActionItem {
   text: string;
   link?: string;
+  linkAriaLabel?: string;
+  linkIcon?: LucideIcon;
 }
 
 interface IndicatorItem {
   text: string;
 }
 
+interface SummaryObjectiveItem {
+  icon: string;
+  label: string;
+}
+
+interface SummaryActionItem {
+  label: string;
+  icon?: LucideIcon;
+  iconClassName?: string;
+  link?: string;
+  linkAriaLabel?: string;
+}
+
+interface SummaryIndicatorItem {
+  label: string;
+  value: string;
+}
+
+interface SummaryData {
+  objectives?: SummaryObjectiveItem[];
+  actions?: SummaryActionItem[];
+  indicators?: SummaryIndicatorItem[];
+}
+
 interface PSDAxeLayoutProps {
+  axeId?: number;
   title: string;
   subtitle: string;
+  summary?: SummaryData;
   objectifs: ObjectifItem[];
   actions: ActionItem[];
   indicators: IndicatorItem[];
 }
 
 const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
+  axeId,
   title,
   subtitle,
+  summary,
   objectifs,
   actions,
   indicators
 }) => {
+  const sectionId = axeId ? `axe-${axeId}` : undefined;
+
   return (
-    <div>
-      <h3 className="text-xl font-playfair font-bold text-french-blue mb-4">
-        {title}
-      </h3>
-      <p className="text-lg font-medium font-raleway text-gray-800 mb-4">
-        {subtitle}
-      </p>
-      
-      <div className="mt-6 space-y-4">
-        <div>
-          <h4 className="font-semibold text-gray-900 mb-2">Objectifs</h4>
-          <ul className="list-disc pl-5 space-y-1 text-gray-700 font-raleway">
+    <section id={sectionId} className="space-y-10">
+      <header className="space-y-3">
+        <h3 className="text-xl font-playfair font-bold text-french-blue md:text-2xl">
+          {title}
+        </h3>
+        <p className="text-lg font-medium font-raleway text-gray-800">
+          {subtitle}
+        </p>
+      </header>
+
+      {summary && (
+        <div className="grid gap-6 md:grid-cols-3">
+          {summary.objectives?.length ? (
+            <article className="flex flex-col rounded-2xl bg-white p-6 shadow-sm ring-1 ring-french-blue/10">
+              <div className="mb-4 flex items-center gap-3">
+                <span className="rounded-full bg-french-blue/10 p-2 text-french-blue">
+                  <Target className="h-6 w-6" aria-hidden="true" />
+                </span>
+                <h4 className="text-lg font-semibold text-slate-900">Objectifs clés</h4>
+              </div>
+              <ul className="grid gap-2">
+                {summary.objectives.map((item) => (
+                  <li
+                    key={item.label}
+                    className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700"
+                  >
+                    <span aria-hidden="true">{item.icon}</span>
+                    <span>{item.label}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ) : null}
+
+          {summary.actions?.length ? (
+            <article className="flex flex-col rounded-2xl bg-white p-6 shadow-sm ring-1 ring-french-blue/10">
+              <div className="mb-4 flex items-center gap-3">
+                <span className="rounded-full bg-french-blue/10 p-2 text-french-blue">
+                  <ListChecks className="h-6 w-6" aria-hidden="true" />
+                </span>
+                <h4 className="text-lg font-semibold text-slate-900">Actions phares</h4>
+              </div>
+              <ul className="grid gap-2">
+                {summary.actions.map((item) => {
+                  const IconComponent = item.icon;
+
+                  const content = (
+                    <span className="flex w-full items-center justify-between gap-3">
+                      <span className="flex items-center gap-2">
+                        {IconComponent ? (
+                          <span
+                            className={`flex h-8 w-8 items-center justify-center rounded-full bg-slate-50 ${
+                              item.iconClassName ?? 'text-french-blue'
+                            }`}
+                            aria-hidden="true"
+                          >
+                            <IconComponent className="h-4 w-4" aria-hidden="true" />
+                          </span>
+                        ) : null}
+                        <span className="text-left text-sm font-medium text-slate-700">
+                          {item.label}
+                        </span>
+                      </span>
+                      {item.link ? (
+                        <ArrowRight className="h-4 w-4 text-french-blue" aria-hidden="true" />
+                      ) : null}
+                    </span>
+                  );
+
+                  return (
+                    <li
+                      key={item.label}
+                      className="rounded-xl bg-slate-100 text-sm font-medium text-slate-700"
+                    >
+                      {item.link ? (
+                        <Link
+                          to={item.link}
+                          className="inline-flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 transition hover:bg-slate-200 hover:text-french-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue"
+                          aria-label={item.linkAriaLabel ?? `En savoir plus – ${item.label}`}
+                        >
+                          {content}
+                        </Link>
+                      ) : (
+                        <div className="inline-flex w-full items-center justify-between gap-3 px-3 py-2">
+                          {content}
+                        </div>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </article>
+          ) : null}
+
+          {summary.indicators?.length ? (
+            <article className="flex flex-col rounded-2xl bg-white p-6 shadow-sm ring-1 ring-french-blue/10">
+              <div className="mb-4 flex items-center gap-3">
+                <span className="rounded-full bg-french-blue/10 p-2 text-french-blue">
+                  <BarChart3 className="h-6 w-6" aria-hidden="true" />
+                </span>
+                <h4 className="text-lg font-semibold text-slate-900">Indicateurs clés</h4>
+              </div>
+              <dl className="grid gap-3">
+                {summary.indicators.map((item) => (
+                  <div
+                    key={item.label}
+                    className="rounded-xl bg-slate-100 px-3 py-2"
+                  >
+                    <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                      {item.label}
+                    </dt>
+                    <dd className="text-base font-semibold text-slate-900">
+                      {item.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </article>
+          ) : null}
+        </div>
+      )}
+
+      <section className="space-y-8">
+        <div
+          id={sectionId ? `${sectionId}-objectifs` : undefined}
+          className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <h4 className="mb-3 text-lg font-semibold text-slate-900">Objectifs détaillés</h4>
+          <ul className="list-disc space-y-2 pl-5 text-gray-700 font-raleway">
             {objectifs.map((item, index) => (
               <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
             ))}
           </ul>
         </div>
-        
-        <div>
-          <h4 className="font-semibold text-gray-900 mb-2">Actions prioritaires</h4>
-          <ul className="list-disc pl-5 space-y-1 text-gray-700 font-raleway">
-            {actions.map((item, index) => {
-              const hasLink = Boolean(item.link);
-              const textContent = item.text.toLowerCase();
-              const iconType = textContent.includes('harcèlement')
-                ? 'harcelement'
-                : textContent.includes('restauration')
-                ? 'restauration'
-                : null;
-              const IconComponent = iconType === 'harcelement' ? ShieldCheck : iconType === 'restauration' ? Utensils : null;
-              const ariaLabelSuffix = iconType === 'harcelement'
-                ? 'Prévention du harcèlement'
-                : iconType === 'restauration'
-                ? 'Restauration scolaire'
-                : '';
 
-              if (!hasLink || !IconComponent || !item.link) {
+        <div
+          id={sectionId ? `${sectionId}-actions` : undefined}
+          className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <h4 className="mb-3 text-lg font-semibold text-slate-900">Actions prioritaires détaillées</h4>
+          <ul className="list-disc space-y-3 pl-5 text-gray-700 font-raleway">
+            {actions.map((item, index) => {
+              if (!item.link) {
                 return (
-                  <li key={index} className="list-item">
-                    <span dangerouslySetInnerHTML={{ __html: item.text }}></span>
-                  </li>
+                  <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
                 );
               }
 
+              const LinkIcon = item.linkIcon ?? ArrowRight;
+              const ariaLabel = item.linkAriaLabel ?? 'En savoir plus';
+
               return (
-                <li key={index} className="action-item">
-                  <span className="action-text" dangerouslySetInnerHTML={{ __html: item.text }}></span>
+                <li key={index} className="flex flex-wrap items-center gap-2">
+                  <span dangerouslySetInnerHTML={{ __html: item.text }}></span>
                   <Link
                     to={item.link}
-                    className="btn-link"
-                    aria-label={`En savoir plus – ${ariaLabelSuffix}`}
+                    className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:text-french-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue"
+                    aria-label={ariaLabel}
                   >
-                    <IconComponent className="icon" size={18} aria-hidden="true" />
+                    <LinkIcon className="h-4 w-4" aria-hidden="true" />
                     <span>En savoir plus</span>
                   </Link>
                 </li>
@@ -92,17 +231,20 @@ const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
             })}
           </ul>
         </div>
-        
-        <div>
-          <h4 className="font-semibold text-gray-900 mb-2">Indicateurs</h4>
-          <ul className="list-disc pl-5 space-y-1 text-gray-700 font-raleway">
+
+        <div
+          id={sectionId ? `${sectionId}-indicateurs` : undefined}
+          className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <h4 className="mb-3 text-lg font-semibold text-slate-900">Indicateurs détaillés</h4>
+          <ul className="list-disc space-y-2 pl-5 text-gray-700 font-raleway">
             {indicators.map((item, index) => (
               <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
             ))}
           </ul>
         </div>
-      </div>
-    </div>
+      </section>
+    </section>
   );
 };
 


### PR DESCRIPTION
## Summary
- extend `PSDAxeLayout` with optional summary cards and flexible action links
- refresh Axe 2 content with the merged objectives, actions and indicators
- clean up unused imports in Axe 4 after the layout update

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d040d1ebf08331a84f6dd198eff2fa