### PR TITLE
Restore bullet layout for harassment action link

### DIFF
--- a/src/components/PSDAxe1.tsx
+++ b/src/components/PSDAxe1.tsx
@@ -152,8 +152,8 @@ const PSDAxe1 = () => {
               }
 
               return (
-                <li key={index} className="flex flex-wrap items-center gap-2">
-                  <span dangerouslySetInnerHTML={{ __html: item.text }}></span>
+                <li key={index} className="space-y-2">
+                  <span className="block" dangerouslySetInnerHTML={{ __html: item.text }}></span>
                   <Link
                     to={item.link}
                     className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue"


### PR DESCRIPTION
## Summary
- adjust the action list rendering so items with CTA links keep their bullet styling
- ensure the harassment prevention action text and link render on separate lines to preserve the bullet appearance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d16f7111608331b419161820b5d1d6