### PR TITLE
Update section internationale plan text

### DIFF
--- a/src/components/PSDAxe2.tsx
+++ b/src/components/PSDAxe2.tsx
@@ -75,7 +75,7 @@ const PSDAxe2 = () => {
   const actions = [
     {
       text:
-        '<strong>Sections et certifications internationales</strong> :<br/>• <strong>Déploiement du plan « Section Internationale et BFI »</strong> (2026-2033)<br/>• Recrutement et formation d\'<strong>enseignants locuteurs natifs</strong> ou hautement qualifiés (niveau <strong>C2 CECRL</strong>) pour les disciplines non linguistiques et littéraires.',
+        '• <strong>Déploiement du plan « Section Internationale et BFI »</strong> (2026-2028).',
       link: '/section-internationale-bfi',
       linkAriaLabel: 'En savoir plus – Section internationale et BFI',
       linkIcon: Globe2,


### PR DESCRIPTION
## Summary
- simplify the "Section Internationale et BFI" action entry to keep only the deployment bullet with updated 2026-2028 timeline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d19f840e688331964a313cdcc4c37d