### PR TITLE
Remove redundant capacity rows from hours table

### DIFF
--- a/src/pages/SectionInternationaleBFI.tsx
+++ b/src/pages/SectionInternationaleBFI.tsx
@@ -213,24 +213,6 @@ const SectionInternationaleBFI: React.FC = () => {
       commentaire: '= 4,7 ETP',
       accent: false,
     },
-    {
-      poste: 'Capacité 2026',
-      volume: `${DATA.etp.capacite2026} h / semaine`,
-      commentaire: 'Action RH prioritaire',
-      accent: true,
-    },
-    {
-      poste: 'Capacité 2027',
-      volume: `${DATA.etp.capacite2027} h / semaine`,
-      commentaire: 'Déficit marginal absorbé',
-      accent: false,
-    },
-    {
-      poste: 'Capacité 2028',
-      volume: `${DATA.etp.capacite2028} h / semaine`,
-      commentaire: 'Capacité cible',
-      accent: false,
-    },
   ];
 
   const cards = [


### PR DESCRIPTION
## Summary
- remove the three trailing capacity rows from the Section Internationale BFI hours table

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1bd98e4808331a684869d6a1aba2c