### PR TITLE
Ajoute le DNBi à la foire aux questions

### DIFF
--- a/src/pages/SectionInternationaleBFI.tsx
+++ b/src/pages/SectionInternationaleBFI.tsx
@@ -247,7 +247,7 @@ const SectionInternationaleBFI: React.FC = () => {
     {
       question: 'Quel diplôme ?',
       answer:
-        'La section américaine du Baccalauréat Français International (BFI) en Terminale, gage de reconnaissance internationale.',
+        'Le Diplôme National du Brevet international (DNBi) en 3e et la section américaine du Baccalauréat Français International (BFI) en Terminale, gages de reconnaissance internationale.',
     },
   ];
 


### PR DESCRIPTION
## Summary
- mentionne désormais le Diplôme National du Brevet international (DNBi) en 3e dans la réponse sur les diplômes
- précise que DNBi et BFI sont des gages de reconnaissance internationale

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1be2920008331a20e52ce98ca4668