### PR TITLE
Restore bullet styling for linked actions

### DIFF
--- a/src/components/PSDAxe2.tsx
+++ b/src/components/PSDAxe2.tsx
@@ -75,7 +75,7 @@ const PSDAxe2 = () => {
   const actions = [
     {
       text:
-        '• <strong>Déploiement du plan « Section Internationale et BFI »</strong> (2026-2028).',
+        '<strong>Déploiement du plan « Section Internationale et BFI »</strong> (2026-2028).',
       link: '/section-internationale-bfi',
       linkAriaLabel: 'En savoir plus – Section internationale et BFI',
       linkIcon: Globe2,

--- a/src/components/PSDAxeLayout.tsx
+++ b/src/components/PSDAxeLayout.tsx
@@ -216,16 +216,18 @@ const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
               const ariaLabel = item.linkAriaLabel ?? 'En savoir plus';
 
               return (
-                <li key={index} className="flex flex-wrap items-center gap-2">
-                  <span dangerouslySetInnerHTML={{ __html: item.text }}></span>
-                  <Link
-                    to={item.link}
-                    className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:text-french-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue"
-                    aria-label={ariaLabel}
-                  >
-                    <LinkIcon className="h-4 w-4" aria-hidden="true" />
-                    <span>En savoir plus</span>
-                  </Link>
+                <li key={index}>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span dangerouslySetInnerHTML={{ __html: item.text }}></span>
+                    <Link
+                      to={item.link}
+                      className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:text-french-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue"
+                      aria-label={ariaLabel}
+                    >
+                      <LinkIcon className="h-4 w-4" aria-hidden="true" />
+                      <span>En savoir plus</span>
+                    </Link>
+                  </div>
                 </li>
               );
             })}


### PR DESCRIPTION
## Summary
- remove the hardcoded bullet character from the "Section Internationale et BFI" action so it relies on the list marker only

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2630ce3388331977a63cd9244fa09