### PR TITLE
Remplacer "Actions prioritaires" par "Rubriques"

### DIFF
--- a/src/components/PSDAxe1.tsx
+++ b/src/components/PSDAxe1.tsx
@@ -17,7 +17,7 @@ const PSDAxe1 = () => {
     },
     {
       id: 'details-actions',
-      title: 'Actions prioritaires',
+      title: 'Rubriques',
       icon: ListChecks,
       items: [
         { icon: '❄️', label: 'Rafraîchissement durable' },
@@ -131,7 +131,7 @@ const PSDAxe1 = () => {
         </div>
 
         <div id="details-actions" className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h4 className="mb-3 text-lg font-semibold text-slate-900">Actions prioritaires détaillées</h4>
+          <h4 className="mb-3 text-lg font-semibold text-slate-900">Rubriques détaillées</h4>
           <ul className="list-disc space-y-3 pl-5 text-gray-700 font-raleway">
             {actions.map((item, index) => {
               const hasLink = Boolean(item.link);

--- a/src/components/PSDAxeLayout.tsx
+++ b/src/components/PSDAxeLayout.tsx
@@ -104,7 +104,7 @@ const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
                 <span className="rounded-full bg-french-blue/10 p-2 text-french-blue">
                   <ListChecks className="h-6 w-6" aria-hidden="true" />
                 </span>
-                <h4 className="text-lg font-semibold text-slate-900">Actions phares</h4>
+                <h4 className="text-lg font-semibold text-slate-900">Rubriques phares</h4>
               </div>
               <ul className="grid gap-2">
                 {summary.actions.map((item) => {
@@ -203,7 +203,7 @@ const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
           id={sectionId ? `${sectionId}-actions` : undefined}
           className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
         >
-          <h4 className="mb-3 text-lg font-semibold text-slate-900">Actions prioritaires détaillées</h4>
+          <h4 className="mb-3 text-lg font-semibold text-slate-900">Rubriques détaillées</h4>
           <ul className="list-disc space-y-3 pl-5 text-gray-700 font-raleway">
             {actions.map((item, index) => {
               if (!item.link) {


### PR DESCRIPTION
## Summary
- update the Axe 1 summary card label to display "Rubriques"
- align the detailed section heading in both Axe 1 and the shared layout with the new terminology
- rename the shared layout summary block to "Rubriques phares" so axes 2 à 4 adopt the new wording

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d296f1c1fc8331991218401ae4b22c