### PR TITLE
Remove hero logo from homepage header

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -10,7 +10,7 @@ const Hero = ({ title, subtitle }: HeroProps) => {
   return (
     <section className="bg-gradient-to-r from-french-blue to-blue-700 text-white py-24 md:py-32">
       <div className="container mx-auto px-6">
-        <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-12">
+        <div className="flex flex-col items-start gap-8 md:gap-12">
           <div className="max-w-3xl">
             <h1 className="text-4xl md:text-5xl lg:text-6xl font-playfair font-bold mb-6 opacity-0 animate-fade-in">
               {title}
@@ -18,17 +18,6 @@ const Hero = ({ title, subtitle }: HeroProps) => {
             <p className="text-xl md:text-2xl font-raleway font-light opacity-0 animate-fade-in-delay-1">
               {subtitle}
             </p>
-          </div>
-          <div className="w-full md:w-auto flex justify-center md:justify-end">
-            <div className="h-48 w-48 md:h-64 md:w-64 border-4 border-red-500 flex items-center justify-center opacity-0 animate-fade-in-delay-2">
-              <div className="h-32 w-32 md:h-44 md:w-44 rounded-full bg-white/95 shadow-xl flex items-center justify-center">
-                <img
-                  src="/images/logo-psd.svg"
-                  alt="Logo du Plan Stratégique de Développement"
-                  className="h-24 w-24 md:h-32 md:w-32 object-contain drop-shadow-lg"
-                />
-              </div>
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove the decorative logo block from the hero header to leave only the textual content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7ce2fe330833185574d7b639000b3