### PR TITLE
Replace ICT tab placeholder with detailed content

### DIFF
--- a/src/pages/PlanMaintenanceStrategique.tsx
+++ b/src/pages/PlanMaintenanceStrategique.tsx
@@ -320,7 +320,7 @@ const PlanMaintenanceStrategique = () => {
               </TabsContent>
 
               <TabsContent value="informatique">
-                <p className="text-gray-700">Contenu en construction</p>
+                <RenouvellementInformatiqueTabs />
               </TabsContent>
 
               <TabsContent value="acoustique">


### PR DESCRIPTION
## Summary
- replace the placeholder paragraph in the Renouvellement Informatique tab with the dedicated RenouvellementInformatiqueTabs component so it shows detailed content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7dd84a27083319a6e12da70db4d28