### PR TITLE
Remove soft skills shortcut from navigation menus

### DIFF
--- a/src/components/navigation/DesktopMenu.tsx
+++ b/src/components/navigation/DesktopMenu.tsx
@@ -27,9 +27,6 @@ const DesktopMenu = ({ isActive }: DesktopMenuProps) => {
           Plan Stratégique
         </DesktopNavItem>
 
-        <DesktopNavItem to="/curriculum-soft-skills" isActive={isActive('/curriculum-soft-skills')}>
-          Soft Skills & Éloquence
-        </DesktopNavItem>
       </NavigationMenuList>
     </NavigationMenu>
   );

--- a/src/components/navigation/MobileMenu.tsx
+++ b/src/components/navigation/MobileMenu.tsx
@@ -61,13 +61,6 @@ const MobileMenu = ({ id, mobileMenuOpen, setMobileMenuOpen, isActive }: MobileM
           Plan Stratégique
         </MobileNavItem>
 
-        <MobileNavItem
-          to="/curriculum-soft-skills"
-          isActive={isActive('/curriculum-soft-skills')}
-          onClick={() => setMobileMenuOpen(false)}
-        >
-          Soft Skills & Éloquence
-        </MobileNavItem>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove the desktop navigation link to the soft skills curriculum page
- remove the corresponding entry from the mobile navigation drawer
- keep access to the page via the Axe 4 curriculum action card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d85ff582b8833195f6d16b3ca597a1