### PR TITLE
Adjust frise soft skills heading size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -343,6 +343,8 @@
 }
 
 .frise-softskills h2 {
-  font: 700 1.4rem/1.2 system-ui, Segoe UI, Roboto, Arial;
+  font-weight: 700;
+  font-size: clamp(1.5rem, 1.15rem + 1vw, 2.25rem);
+  line-height: 1.2;
   margin: 0 0 0.75rem;
 }


### PR DESCRIPTION
## Summary
- replace the fixed `.frise-softskills h2` font declaration with a responsive clamp-based size
- preserve the Playfair font family by avoiding overriding the JSX-specified class and maintain dark-mode contrast inheritance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d861f247d483319865332d2da22209