### PR TITLE
Improve PSD tabs responsiveness

### DIFF
--- a/src/components/PSDTabs.tsx
+++ b/src/components/PSDTabs.tsx
@@ -11,38 +11,38 @@ import PSDAxeTransversal from './PSDAxeTransversal';
 const PSDTabs = () => {
   return (
     <Tabs defaultValue="axe1" className="w-full">
-      <TabsList className="grid grid-cols-5 mb-8">
+      <TabsList className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2 mb-8">
         <TabsTrigger
           value="axe1"
-          className="group flex flex-col items-center py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
+          className="group flex flex-col items-center justify-center w-full px-3 py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
         >
           <Target className="mb-1 h-6 w-6 md:h-8 md:w-8 transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]" />
           <span className="block text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 1</span>
         </TabsTrigger>
         <TabsTrigger
           value="axe2"
-          className="group flex flex-col items-center py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
+          className="group flex flex-col items-center justify-center w-full px-3 py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
         >
           <Users className="mb-1 h-6 w-6 md:h-8 md:w-8 transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]" />
           <span className="block text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 2</span>
         </TabsTrigger>
         <TabsTrigger
           value="axe3"
-          className="group flex flex-col items-center py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
+          className="group flex flex-col items-center justify-center w-full px-3 py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
         >
           <Sparkles className="mb-1 h-6 w-6 md:h-8 md:w-8 transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]" />
           <span className="block text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 3</span>
         </TabsTrigger>
         <TabsTrigger
           value="axe4"
-          className="group flex flex-col items-center py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
+          className="group flex flex-col items-center justify-center w-full px-3 py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
         >
           <GraduationCap className="mb-1 h-6 w-6 md:h-8 md:w-8 transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]" />
           <span className="block text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 4</span>
         </TabsTrigger>
         <TabsTrigger
           value="axe5"
-          className="group flex flex-col items-center py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
+          className="group flex flex-col items-center justify-center w-full px-3 py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
         >
           <LayoutDashboard className="mb-1 h-6 w-6 md:h-8 md:w-8 transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]" />
           <span className="block text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Transversal</span>


### PR DESCRIPTION
## Summary
- make the PSD tab bar responsive with a dynamic column count across breakpoints
- ensure each tab trigger stretches with padding for a comfortable tap target on mobile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d86c0e81e08331bae1752650cf5a79