### PR TITLE
Allow PCParLyceen action buttons to wrap on small screens

### DIFF
--- a/src/pages/PCParLyceen.tsx
+++ b/src/pages/PCParLyceen.tsx
@@ -47,7 +47,7 @@ const PCParLyceen = () => {
       </div>
       
       <div className="container mx-auto px-6 py-12">
-        <div className="flex space-x-4 mb-8">
+        <div className="flex flex-wrap gap-4 mb-8 items-center justify-center sm:justify-start">
           <Button variant="outline" asChild>
             <Link to="/plan-strategique">
               <ArrowLeft className="mr-2" />


### PR DESCRIPTION
## Summary
- allow the action buttons on the PC Par Lycéen page to wrap and center-align on small screens to avoid overflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d86c11956c833188c4260544569544