### PR TITLE
Replace PSD axe HTML strings with JSX nodes

### DIFF
--- a/src/components/PSDAxe1.tsx
+++ b/src/components/PSDAxe1.tsx
@@ -40,41 +40,159 @@ const PSDAxe1 = () => {
 
   const objectifs = [
     {
-      text:
-        '<strong>Bien-être et accompagnement des élèves</strong> : Garantir un <strong>environnement scolaire sain, climatisé et agréable</strong>, développer une <strong>culture du bien-être physique, mental, social et environnemental</strong> et répondre aux <strong>besoins particuliers des élèves</strong>.'
+      content: (
+        <>
+          <strong>Bien-être et accompagnement des élèves</strong> : Garantir un{' '}
+          <strong>environnement scolaire sain, climatisé et agréable</strong>, développer une{' '}
+          <strong>culture du bien-être physique, mental, social et environnemental</strong> et répondre aux{' '}
+          <strong>besoins particuliers des élèves</strong>.
+        </>
+      )
     },
     {
-      text:
-        '<strong>Climat scolaire et coopération éducative</strong> : Renforcer la <strong>confiance et la coopération</strong> entre élèves, familles et personnels, <strong>responsabiliser les élèves</strong> dans la vie de l\'établissement et consolider un <strong>climat scolaire</strong> fondé sur des règles et des valeurs partagées.'
+      content: (
+        <>
+          <strong>Climat scolaire et coopération éducative</strong> : Renforcer la{' '}
+          <strong>confiance et la coopération</strong> entre élèves, familles et personnels,{' '}
+          <strong>responsabiliser les élèves</strong> dans la vie de l'établissement et consolider un{' '}
+          <strong>climat scolaire</strong> fondé sur des règles et des valeurs partagées.
+        </>
+      )
     },
     {
-      text:
-        '<strong>Qualité et durabilité des services</strong> : Améliorer la <strong>qualité des services</strong> (restauration, transport, hygiène) et pérenniser l\'engagement du LFJP en matière de <strong>développement durable</strong> dans la dynamique <strong>E³D</strong>.'
+      content: (
+        <>
+          <strong>Qualité et durabilité des services</strong> : Améliorer la{' '}
+          <strong>qualité des services</strong> (restauration, transport, hygiène) et pérenniser l'engagement du LFJP en matière
+          de <strong>développement durable</strong> dans la dynamique <strong>E³D</strong>.
+        </>
+      )
     }
   ];
 
   const actions = [
-    { text: '<strong>Rafraîchissement durable des salles</strong> : <strong>plan de climatisation progressive</strong> et solutions écologiques (ombrages, végétalisation, rénovation)' },
-    { text: '<strong>Parcours santé-bien-être</strong> : hygiène, alimentation, activité physique et <strong>équilibre mental</strong>' },
-    { text: '<strong>Prévention du harcèlement</strong> : <strong>médiateurs élèves</strong>, pratiques restauratives, programme <strong>pHARe</strong>', link: '/protocole-phare' },
-    { text: '<strong>Expression et participation</strong> : conseils de vie, <strong>budgets participatifs</strong>, comités mixtes' },
-    { text: '<strong>Parentalité et coéducation</strong> : rencontres et ateliers pour mieux suivre la scolarité' },
-    { text: '<strong>Restauration scolaire</strong> : audit, consultation des usagers, mise en œuvre 2026-2027', link: '/construction-cantine' },
     {
-      text: 'Politique <strong>E³D</strong> consolidée : <strong>référents</strong> et <strong>éco-délégués</strong>, comité de pilotage, projets interdisciplinaires, plan d\'action annuel aligné <strong>EFE³D</strong>',
-      link: '/politique-e3d'
+      content: (
+        <>
+          <strong>Rafraîchissement durable des salles</strong> :{' '}
+          <strong>plan de climatisation progressive</strong> et solutions écologiques (ombrages, végétalisation, rénovation)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Parcours santé-bien-être</strong> : hygiène, alimentation, activité physique et{' '}
+          <strong>équilibre mental</strong>
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Prévention du harcèlement</strong> : <strong>médiateurs élèves</strong>, pratiques restauratives, programme{' '}
+          <strong>pHARe</strong>
+        </>
+      ),
+      link: '/protocole-phare',
+      linkAriaLabel: 'En savoir plus – Prévention du harcèlement',
+      linkIcon: ShieldCheck
+    },
+    {
+      content: (
+        <>
+          <strong>Expression et participation</strong> : conseils de vie,{' '}
+          <strong>budgets participatifs</strong>, comités mixtes
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Parentalité et coéducation</strong> : rencontres et ateliers pour mieux suivre la scolarité
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Restauration scolaire</strong> : audit, consultation des usagers, mise en œuvre 2026-2027
+        </>
+      ),
+      link: '/construction-cantine',
+      linkAriaLabel: 'En savoir plus – Restauration scolaire',
+      linkIcon: Utensils
+    },
+    {
+      content: (
+        <>
+          Politique <strong>E³D</strong> consolidée : <strong>référents</strong> et <strong>éco-délégués</strong>, comité de
+          pilotage, projets interdisciplinaires, plan d'action annuel aligné <strong>EFE³D</strong>
+        </>
+      ),
+      link: '/politique-e3d',
+      linkAriaLabel: 'En savoir plus – Politique E3D',
+      linkIcon: Leaf
     }
   ];
   
   const indicators = [
-    { text: '<strong>Taux d\'élèves</strong> se déclarant « <strong>bien au LFJP</strong> » (objectif : <strong>+15 pts</strong> au lycée)' },
-    { text: '<strong>Taux de satisfaction</strong> sur la climatisation, les sanitaires, la cantine (élèves et parents)' },
-    { text: '<strong>Nombre de familles accompagnées</strong> dans le cadre de dispositifs de soutien à la parentalité' },
-    { text: '<strong>Taux d\'élèves</strong> bénéficiant d\'un <strong>aménagement</strong> ou d\'un <strong>accompagnement pédagogique</strong>' },
-    { text: '<strong>Avancement du plan de restauration scolaire</strong> (étapes validées)' },
-    { text: '<strong>Taux de satisfaction global</strong> sur le <strong>climat scolaire</strong> (par enquête ELCS)' },
-    { text: '<strong>Nombre de projets E3D</strong> portés par cycle' },
-    { text: 'Maintien du <strong>label EFE3D niveau 3</strong> à chaque renouvellement triennal' }
+    {
+      content: (
+        <>
+          <strong>Taux d'élèves</strong> se déclarant « <strong>bien au LFJP</strong> » (objectif :{' '}
+          <strong>+15 pts</strong> au lycée)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Taux de satisfaction</strong> sur la climatisation, les sanitaires, la cantine (élèves et parents)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Nombre de familles accompagnées</strong> dans le cadre de dispositifs de soutien à la parentalité
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Taux d'élèves</strong> bénéficiant d'un <strong>aménagement</strong> ou d'un{' '}
+          <strong>accompagnement pédagogique</strong>
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Avancement du plan de restauration scolaire</strong> (étapes validées)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Taux de satisfaction global</strong> sur le <strong>climat scolaire</strong> (par enquête ELCS)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Nombre de projets E3D</strong> portés par cycle
+        </>
+      )
+    },
+    {
+      content: (
+        <>Maintien du <strong>label EFE3D niveau 3</strong> à chaque renouvellement triennal</>
+      )
+    }
   ];
 
   return (
@@ -125,7 +243,7 @@ const PSDAxe1 = () => {
           <h4 className="mb-3 text-lg font-semibold text-slate-900">Objectifs détaillés</h4>
           <ul className="list-disc space-y-2 pl-5 text-gray-700 font-raleway">
             {objectifs.map((item, index) => (
-              <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
+              <li key={index}>{item.content}</li>
             ))}
           </ul>
         </div>
@@ -134,44 +252,19 @@ const PSDAxe1 = () => {
           <h4 className="mb-3 text-lg font-semibold text-slate-900">Rubriques détaillées</h4>
           <ul className="list-disc space-y-3 pl-5 text-gray-700 font-raleway">
             {actions.map((item, index) => {
-              const hasLink = Boolean(item.link);
-              const textContent = item.text.toLowerCase();
-              const iconType = textContent.includes('harcèlement')
-                ? 'harcelement'
-                : textContent.includes('restauration')
-                ? 'restauration'
-                : textContent.includes('e³d')
-                ? 'e3d'
-                : null;
-              const IconComponent =
-                iconType === 'harcelement'
-                  ? ShieldCheck
-                  : iconType === 'restauration'
-                  ? Utensils
-                  : iconType === 'e3d'
-                  ? Leaf
-                  : null;
-              const ariaLabelSuffix = iconType === 'harcelement'
-                ? 'Prévention du harcèlement'
-                : iconType === 'restauration'
-                ? 'Restauration scolaire'
-                : iconType === 'e3d'
-                ? 'Politique E3D'
-                : '';
-
-              if (!hasLink || !IconComponent || !item.link) {
-                return (
-                  <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
-                );
+              if (!item.link) {
+                return <li key={index}>{item.content}</li>;
               }
+
+              const IconComponent = item.linkIcon ?? ShieldCheck;
 
               return (
                 <li key={index} className="space-y-2">
-                  <span className="block" dangerouslySetInnerHTML={{ __html: item.text }}></span>
+                  <span className="block text-gray-700">{item.content}</span>
                   <Link
                     to={item.link}
                     className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue"
-                    aria-label={`En savoir plus – ${ariaLabelSuffix}`}
+                    aria-label={item.linkAriaLabel ?? 'En savoir plus'}
                   >
                     <IconComponent className="h-4 w-4" aria-hidden="true" />
                     <span>En savoir plus</span>
@@ -189,7 +282,7 @@ const PSDAxe1 = () => {
           <h4 className="mb-3 text-lg font-semibold text-slate-900">Indicateurs détaillés</h4>
           <ul className="list-disc space-y-2 pl-5 text-gray-700 font-raleway">
             {indicators.map((item, index) => (
-              <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
+              <li key={index}>{item.content}</li>
             ))}
           </ul>
         </div>

--- a/src/components/PSDAxe2.tsx
+++ b/src/components/PSDAxe2.tsx
@@ -59,45 +59,87 @@ const PSDAxe2 = () => {
 
   const objectifs = [
     {
-      text:
-        '<strong>Plurilinguisme et diversité</strong> : Faire de la <strong>diversité linguistique et culturelle</strong> un levier d\'apprentissage et de citoyenneté.',
+      content: (
+        <>
+          <strong>Plurilinguisme et diversité</strong> : Faire de la{' '}
+          <strong>diversité linguistique et culturelle</strong> un levier d'apprentissage et de citoyenneté.
+        </>
+      ),
     },
     {
-      text:
-        '<strong>Citoyenneté et ouverture</strong> : Former des élèves <strong>ouverts, tolérants et responsables</strong> dans un <strong>monde multipolaire</strong>.',
+      content: (
+        <>
+          <strong>Citoyenneté et ouverture</strong> : Former des élèves{' '}
+          <strong>ouverts, tolérants et responsables</strong> dans un{' '}
+          <strong>monde multipolaire</strong>.
+        </>
+      ),
     },
     {
-      text:
-        '<strong>Parcours et expériences</strong> : Enrichir les <strong>parcours éducatifs</strong> par des projets et coopérations <strong>interculturels et internationaux</strong>.',
+      content: (
+        <>
+          <strong>Parcours et expériences</strong> : Enrichir les{' '}
+          <strong>parcours éducatifs</strong> par des projets et coopérations{' '}
+          <strong>interculturels et internationaux</strong>.
+        </>
+      ),
     },
   ];
 
   const actions = [
     {
-      text:
-        '<strong>Déploiement du plan « Section Internationale et BFI »</strong> (2026-2028).',
+      content: (
+        <>
+          <strong>Déploiement du plan « Section Internationale et BFI »</strong> (2026-2028).
+        </>
+      ),
       link: '/section-internationale-bfi',
       linkAriaLabel: 'En savoir plus – Section internationale et BFI',
       linkIcon: Globe2,
     },
     {
-      text:
-        '<strong>Ouverture internationale</strong> :<br/>• Développer les <strong>voyages scolaires thématiques</strong> (culturels, scientifiques, sportifs) en tant que leviers pédagogiques d\'ouverture au monde.<br/>• Explorer les <strong>jumelages avec d\'autres lycées français</strong> de l\'étranger et les partenariats <strong>Erasmus+/AEFE</strong>.',
+      content: (
+        <>
+          <strong>Ouverture internationale</strong> :
+          <br />• Développer les <strong>voyages scolaires thématiques</strong> (culturels, scientifiques, sportifs) en tant que
+          leviers pédagogiques d'ouverture au monde.
+          <br />• Explorer les <strong>jumelages avec d'autres lycées français</strong> de l'étranger et les partenariats{' '}
+          <strong>Erasmus+/AEFE</strong>.
+        </>
+      ),
     },
     {
-      text:
-        '<strong>Ouverture locale</strong> :<br/>• Renforcer les <strong>coopérations avec les écoles et établissements voisins</strong> (activités conjointes, projets citoyens, actions artistiques et sportives).<br/>• Organiser une « <strong>Semaine des cultures</strong> » annuelle, durant laquelle les élèves présentent leurs langues, traditions et patrimoines culturels.',
+      content: (
+        <>
+          <strong>Ouverture locale</strong> :
+          <br />• Renforcer les <strong>coopérations avec les écoles et établissements voisins</strong> (activités conjointes,
+          projets citoyens, actions artistiques et sportives).
+          <br />• Organiser une « <strong>Semaine des cultures</strong> » annuelle, durant laquelle les élèves présentent leurs
+          langues, traditions et patrimoines culturels.
+        </>
+      ),
     },
     {
-      text:
-        '<strong>Vie scolaire et climat interculturel</strong> :<br/>• Favoriser la <strong>médiation et la prévention</strong> des incompréhensions interculturelles.<br/>• Intégrer les <strong>langues et cultures des familles</strong> dans la vie de l\'établissement (journées thématiques, interventions de parents).',
+      content: (
+        <>
+          <strong>Vie scolaire et climat interculturel</strong> :
+          <br />• Favoriser la <strong>médiation et la prévention</strong> des incompréhensions interculturelles.
+          <br />• Intégrer les <strong>langues et cultures des familles</strong> dans la vie de l'établissement (journées
+          thématiques, interventions de parents).
+        </>
+      ),
       link: '/mediation-entre-pairs',
       linkAriaLabel: 'Découvrir la médiation entre pairs',
       linkIcon: Handshake,
     },
     {
-      text:
-        '<strong>Politique E3D</strong> avec maintien des <strong>17 objectifs de développement durable</strong>, demande de <strong>labellisation niveau 3</strong>, et présence d\'<strong>éco-délégués</strong>.',
+      content: (
+        <>
+          <strong>Politique E3D</strong> avec maintien des{' '}
+          <strong>17 objectifs de développement durable</strong>, demande de <strong>labellisation niveau 3</strong>, et
+          présence d'<strong>éco-délégués</strong>.
+        </>
+      ),
       link: '/politique-e3d',
       linkAriaLabel: 'En savoir plus – Politique E3D',
       linkIcon: Sprout,
@@ -106,24 +148,29 @@ const PSDAxe2 = () => {
 
   const indicators = [
     {
-      text:
-        'Taux d\'élèves engagés dans des <strong>sections et certifications internationales</strong> (SI, BFI).',
+      content: (
+        <>Taux d'élèves engagés dans des <strong>sections et certifications internationales</strong> (SI, BFI).</>
+      ),
     },
     {
-      text:
-        'Pourcentage d\'<strong>enseignants de LV et DNL locuteurs natifs</strong> ou certifiés C2.',
+      content: (
+        <>Pourcentage d'<strong>enseignants de LV et DNL locuteurs natifs</strong> ou certifiés C2.</>
+      ),
     },
     {
-      text:
-        'Nombre de <strong>partenariats locaux et internationaux</strong> actifs.',
+      content: (
+        <>Nombre de <strong>partenariats locaux et internationaux</strong> actifs.</>
+      ),
     },
     {
-      text:
-        'Taux de satisfaction des élèves et familles concernant l\'<strong>ouverture culturelle et linguistique</strong> (enquêtes climats scolaires).',
+      content: (
+        <>Taux de satisfaction des élèves et familles concernant l'<strong>ouverture culturelle et linguistique</strong> (enquêtes climats scolaires).</>
+      ),
     },
     {
-      text:
-        'Participation annuelle des élèves aux projets de la « <strong>Semaine des cultures</strong> » et aux <strong>jumelages</strong>.',
+      content: (
+        <>Participation annuelle des élèves aux projets de la « <strong>Semaine des cultures</strong> » et aux <strong>jumelages</strong>.</>
+      ),
     },
   ];
 

--- a/src/components/PSDAxe3.tsx
+++ b/src/components/PSDAxe3.tsx
@@ -4,37 +4,135 @@ import PSDAxeLayout from './PSDAxeLayout';
 
 const PSDAxe3 = () => {
   const objectifs = [
-    { text: "Structurer un parcours numérique continu et équitable, de l’élémentaire à la terminale." },
-    { text: "Développer l’esprit critique, la créativité et la responsabilité citoyenne dans l’usage du numérique et de l’intelligence artificielle." },
-    { text: "Favoriser l’innovation, l’entrepreneuriat et les projets numériques connectés au monde professionnel et aux enjeux locaux." }
+    {
+      content: <>Structurer un parcours numérique continu et équitable, de l’élémentaire à la terminale.</>
+    },
+    {
+      content: (
+        <>Développer l’esprit critique, la créativité et la responsabilité citoyenne dans l’usage du numérique et de l’intelligence artificielle.</>
+      )
+    },
+    {
+      content: (
+        <>Favoriser l’innovation, l’entrepreneuriat et les projets numériques connectés au monde professionnel et aux enjeux locaux.</>
+      )
+    }
   ];
   
   const actions = [
-    { text: 'Élaboration d\'un <strong>curriculum numérique spiralaire</strong> de l\'élémentaire à la terminale intégrant le <strong>référentiel PIX</strong> (<em>cycle 3 à terminale</em>)' },
-    { text: 'Introduction progressive du <strong>code</strong> dès le cycle 2, avec consolidation au collège et projets concrets (<em>robotique, applications, jeux éducatifs</em>)' },
-    { text: 'Mise en place d\'un <strong>module IA</strong> au lycée : « <em>comprendre pour maîtriser</em> » (<em>inspiré du guide IA de l\'Éducation nationale</em>)' },
-    { text: 'Déploiement d\'une <strong>éducation au numérique citoyen</strong> (<em>fake news, cyberharcèlement, comportements en ligne, empreinte numérique</em>)' },
-    { text: 'Création d\'un <strong>laboratoire numérique</strong> avec des <strong>projets concrets annuels</strong> portés par les élèves (<em>ex : site écoresponsable, app solidaire…</em>)' },
-    { text: 'Intégration d\'<strong>intervenants extérieurs</strong> (<em>volontaires internationaux, partenaires tech, artistes numériques…</em>)' },
-    { text: 'Élaboration du plan "<strong>Un PC par lycéen</strong>"', link: '/pc-par-lyceen' },
-    { text: '<strong>Amélioration de la connectivité</strong> sur l\'ensemble du site' },
-    { text: 'Mise en place d\'un <strong>plan de renouvellement</strong> pluriannuel du matériel informatique' },
-    { text: 'Organisation de <strong>sorties pédagogiques</strong> et immersions dans des <strong>structures technologiques de référence au Sénégal</strong> (<em>ou à distance</em>)' },
     {
-      text: 'Développement d\'un <strong>fonds de soutien ou mécénat numérique</strong> pour l\'équipement et la formation',
+      content: (
+        <>
+          Élaboration d'un <strong>curriculum numérique spiralaire</strong> de l'élémentaire à la terminale intégrant le{' '}
+          <strong>référentiel PIX</strong> (<em>cycle 3 à terminale</em>)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          Introduction progressive du <strong>code</strong> dès le cycle 2, avec consolidation au collège et projets concrets{' '}
+          (<em>robotique, applications, jeux éducatifs</em>)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          Mise en place d'un <strong>module IA</strong> au lycée : « <em>comprendre pour maîtriser</em> » (<em>inspiré du guide
+          IA de l'Éducation nationale</em>)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          Déploiement d'une <strong>éducation au numérique citoyen</strong> (<em>fake news, cyberharcèlement, comportements en
+          ligne, empreinte numérique</em>)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          Création d'un <strong>laboratoire numérique</strong> avec des <strong>projets concrets annuels</strong> portés par les
+          élèves (<em>ex : site écoresponsable, app solidaire…</em>)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          Intégration d'<strong>intervenants extérieurs</strong> (<em>volontaires internationaux, partenaires tech, artistes
+          numériques…</em>)
+        </>
+      )
+    },
+    {
+      content: (
+        <>Élaboration du plan « <strong>Un PC par lycéen</strong> »</>
+      ),
+      link: '/pc-par-lyceen'
+    },
+    {
+      content: <><strong>Amélioration de la connectivité</strong> sur l'ensemble du site</>
+    },
+    {
+      content: (
+        <>Mise en place d'un <strong>plan de renouvellement</strong> pluriannuel du matériel informatique</>
+      )
+    },
+    {
+      content: (
+        <>
+          Organisation de <strong>sorties pédagogiques</strong> et immersions dans des{' '}
+          <strong>structures technologiques de référence au Sénégal</strong> (<em>ou à distance</em>)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          Développement d'un <strong>fonds de soutien ou mécénat numérique</strong> pour l'équipement et la formation
+        </>
+      ),
       link: '/mecenat-numerique',
       linkAriaLabel: 'Consulter la fiche-action Mécénat numérique'
     }
   ];
   
   const indicators = [
-    { text: 'Taux d\'élèves <strong>certifiés PIX</strong> par cycle (<em>cycle 4, lycée</em>)' },
-    { text: 'Nombre de <strong>projets numériques interdisciplinaires</strong> par an' },
-    { text: 'Taux d\'élèves ayant participé à un projet <strong>IA, coding</strong> ou <strong>cybersécurité</strong>' },
-    { text: 'Taux de <strong>lycéens équipés en matériel personnel</strong> (<em>objectif 1 PC par lycéen</em>)' },
-    { text: 'Taux de <strong>couverture WiFi / vitesse de connectivité</strong> par zone du lycée' },
-    { text: 'Taux de <strong>satisfaction numérique</strong> dans les enquêtes' },
-    { text: 'Nombre de <strong>partenariats/mécénats</strong> liés au <strong>numérique éducatif</strong>' }
+    {
+      content: (
+        <>Taux d'élèves <strong>certifiés PIX</strong> par cycle (<em>cycle 4, lycée</em>)</>
+      )
+    },
+    {
+      content: <>Nombre de <strong>projets numériques interdisciplinaires</strong> par an</>
+    },
+    {
+      content: (
+        <>Taux d'élèves ayant participé à un projet <strong>IA, coding</strong> ou <strong>cybersécurité</strong></>
+      )
+    },
+    {
+      content: (
+        <>Taux de <strong>lycéens équipés en matériel personnel</strong> (<em>objectif 1 PC par lycéen</em>)</>
+      )
+    },
+    {
+      content: (
+        <>Taux de <strong>couverture WiFi / vitesse de connectivité</strong> par zone du lycée</>
+      )
+    },
+    {
+      content: <>Taux de <strong>satisfaction numérique</strong> dans les enquêtes</>
+    },
+    {
+      content: (
+        <>Nombre de <strong>partenariats/mécénats</strong> liés au <strong>numérique éducatif</strong></>
+      )
+    }
   ];
 
   return (

--- a/src/components/PSDAxe4.tsx
+++ b/src/components/PSDAxe4.tsx
@@ -4,35 +4,158 @@ import PSDAxeLayout from './PSDAxeLayout';
 
 const PSDAxe4 = () => {
   const objectifs = [
-    { text: 'Maintenir le <strong>niveau d\'excellence</strong> et poursuivre la montée en puissance de la <strong>réussite aux examens</strong>' },
-    { text: 'Développer les <strong>compétences psychosociales et humaines</strong> des élèves (<strong>soft skills</strong>) : prise de parole, coopération, gestion de l\'échec, résilience, esprit critique, engagement citoyen' },
-    { text: 'Encourager l\'<strong>autonomie</strong>, la <strong>persévérance</strong> et la capacité à s\'orienter de manière éclairée' },
-    { text: 'Valoriser toutes les formes de <strong>réussite</strong> : scolaire, artistique, humaine, citoyenne, collective' },
-    { text: 'Faire du <strong>LFJP une école de la confiance et du rebond</strong> : apprendre à apprendre, à s\'adapter, à se relever' },
-    { text: 'Renforcer les liens avec les <strong>anciens élèves (alumni)</strong> et créer une <strong>communauté intergénérationnelle</strong> inspirante' },
-    { text: 'Impliquer pleinement les <strong>familles</strong> dans les parcours de réussite des élèves' }
+    {
+      content: (
+        <>Maintenir le <strong>niveau d'excellence</strong> et poursuivre la montée en puissance de la{' '}
+        <strong>réussite aux examens</strong></>
+      )
+    },
+    {
+      content: (
+        <>
+          Développer les <strong>compétences psychosociales et humaines</strong> des élèves (<strong>soft skills</strong>) :
+          prise de parole, coopération, gestion de l'échec, résilience, esprit critique, engagement citoyen
+        </>
+      )
+    },
+    {
+      content: (
+        <>Encourager l'<strong>autonomie</strong>, la <strong>persévérance</strong> et la capacité à s'orienter de manière éclairée</>
+      )
+    },
+    {
+      content: (
+        <>Valoriser toutes les formes de <strong>réussite</strong> : scolaire, artistique, humaine, citoyenne, collective</>
+      )
+    },
+    {
+      content: (
+        <>Faire du <strong>LFJP une école de la confiance et du rebond</strong> : apprendre à apprendre, à s'adapter, à se relever</>
+      )
+    },
+    {
+      content: (
+        <>
+          Renforcer les liens avec les <strong>anciens élèves (alumni)</strong> et créer une{' '}
+          <strong>communauté intergénérationnelle</strong> inspirante
+        </>
+      )
+    },
+    {
+      content: (
+        <>Impliquer pleinement les <strong>familles</strong> dans les parcours de réussite des élèves</>
+      )
+    }
   ];
   
   const actions = [
     {
-      text: '<strong>Curriculum vertical « Soft Skills & Éloquence »</strong> : parcours PS → Terminale structurant prise de parole, estime de soi, techniques oratoires et leadership.',
+      content: (
+        <>
+          <strong>Curriculum vertical « Soft Skills & Éloquence »</strong> : parcours PS → Terminale structurant prise de
+          parole, estime de soi, techniques oratoires et leadership.
+        </>
+      ),
       link: '/curriculum-soft-skills',
       linkAriaLabel: 'Découvrir le curriculum Soft Skills & Éloquence',
     },
-    { text: '<strong>Valorisation de l\'erreur et de la persévérance</strong> :<br/>• <strong>Pédagogies explicites</strong> sur l\'erreur constructive<br/>• <strong>Interventions d\'anciens élèves</strong> autour de leurs parcours<br/>• Programme « <strong>Cultiver l\'audace</strong> » valorisant les initiatives étudiantes' },
-    { text: '<strong>Parcours de la Réussite citoyenne</strong> :<br/>• <strong>Projets solidaires et participatifs</strong> (ex. budgets participatifs)<br/>• Modules de formation à l\'<strong>engagement citoyen</strong>' },
-    { text: '<strong>Éducation financière et à la vie autonome</strong> :<br/>• Ateliers sur la <strong>gestion budgétaire</strong> et la <strong>vie étudiante post-bac</strong><br/>• Interventions de <strong>professionnels et parents volontaires</strong>' },
-    { text: '<strong>Réseau d\'alumni et mentorat</strong> :<br/>• Constitution d\'une <strong>base de données d\'anciens élèves</strong><br/>• <strong>Mentorat lycéens / alumni</strong><br/>• Rubrique « <strong>Les Oiseaux de Passage</strong> » valorisée dans la communication interne' },
-    { text: '<strong>Soutien à l\'orientation</strong> :<br/>• <strong>Accompagnement personnalisé</strong> dans le cadre du Parcours Avenir<br/>• <strong>Stages, forums métiers, espace orientation</strong>' }
+    {
+      content: (
+        <>
+          <strong>Valorisation de l'erreur et de la persévérance</strong> :
+          <br />• <strong>Pédagogies explicites</strong> sur l'erreur constructive
+          <br />• <strong>Interventions d'anciens élèves</strong> autour de leurs parcours
+          <br />• Programme « <strong>Cultiver l'audace</strong> » valorisant les initiatives étudiantes
+        </>
+      ),
+    },
+    {
+      content: (
+        <>
+          <strong>Parcours de la Réussite citoyenne</strong> :
+          <br />• <strong>Projets solidaires et participatifs</strong> (ex. budgets participatifs)
+          <br />• Modules de formation à l'<strong>engagement citoyen</strong>
+        </>
+      ),
+    },
+    {
+      content: (
+        <>
+          <strong>Éducation financière et à la vie autonome</strong> :
+          <br />• Ateliers sur la <strong>gestion budgétaire</strong> et la{' '}
+          <strong>vie étudiante post-bac</strong>
+          <br />• Interventions de <strong>professionnels et parents volontaires</strong>
+        </>
+      ),
+    },
+    {
+      content: (
+        <>
+          <strong>Réseau d'alumni et mentorat</strong> :
+          <br />• Constitution d'une <strong>base de données d'anciens élèves</strong>
+          <br />• <strong>Mentorat lycéens / alumni</strong>
+          <br />• Rubrique « <strong>Les Oiseaux de Passage</strong> » valorisée dans la communication interne
+        </>
+      ),
+    },
+    {
+      content: (
+        <>
+          <strong>Soutien à l'orientation</strong> :
+          <br />• <strong>Accompagnement personnalisé</strong> dans le cadre du Parcours Avenir
+          <br />• <strong>Stages, forums métiers, espace orientation</strong>
+        </>
+      ),
+    },
   ];
   
   const indicators = [
-    { text: '<strong>% des élèves participant</strong> à un <strong>club citoyen, débat, théâtre, journal</strong> (≥ <strong>80 % collège/lycée</strong>)' },
-    { text: '<strong>% d\'élèves déclarant</strong> « <strong>savoir rebondir après un échec</strong> » (via enquête climat) (<strong>+15 pts</strong> par rapport à 2024)' },
-    { text: '<strong>% d\'élèves impliqués</strong> dans un <strong>projet citoyen ou solidaire</strong> (<strong>100 % cycle 4 et lycée</strong>)' },
-    { text: '<strong>% d\'élèves accompagnés individuellement</strong> en terminale (<strong>100 %</strong>)' },
-    { text: '<strong>Nombre d\'alumni mobilisés</strong> par an (≥ <strong>30 dès 2027</strong>)' },
-    { text: '<strong>Taux de satisfaction</strong> sur l\'accompagnement à la réussite (enquêtes) (≥ <strong>90 %</strong>)' }
+    {
+      content: (
+        <>
+          <strong>% des élèves participant</strong> à un <strong>club citoyen, débat, théâtre, journal</strong> (≥{' '}
+          <strong>80 % collège/lycée</strong>)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>% d'élèves déclarant</strong> « <strong>savoir rebondir après un échec</strong> » (via enquête climat) ({' '}
+          <strong>+15 pts</strong> par rapport à 2024)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>% d'élèves impliqués</strong> dans un <strong>projet citoyen ou solidaire</strong> ({' '}
+          <strong>100 % cycle 4 et lycée</strong>)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>% d'élèves accompagnés individuellement</strong> en terminale (<strong>100 %</strong>)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Nombre d'alumni mobilisés</strong> par an (≥ <strong>30 dès 2027</strong>)
+        </>
+      )
+    },
+    {
+      content: (
+        <>
+          <strong>Taux de satisfaction</strong> sur l'accompagnement à la réussite (enquêtes) (≥{' '}
+          <strong>90 %</strong>)
+        </>
+      )
+    }
   ];
 
   return (

--- a/src/components/PSDAxeLayout.tsx
+++ b/src/components/PSDAxeLayout.tsx
@@ -4,18 +4,18 @@ import type { LucideIcon } from 'lucide-react';
 import { ArrowRight, BarChart3, ListChecks, Target } from 'lucide-react';
 
 interface ObjectifItem {
-  text: string;
+  content: React.ReactNode;
 }
 
 interface ActionItem {
-  text: string;
+  content: React.ReactNode;
   link?: string;
   linkAriaLabel?: string;
   linkIcon?: LucideIcon;
 }
 
 interface IndicatorItem {
-  text: string;
+  content: React.ReactNode;
 }
 
 interface SummaryObjectiveItem {
@@ -194,7 +194,7 @@ const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
           <h4 className="mb-3 text-lg font-semibold text-slate-900">Objectifs détaillés</h4>
           <ul className="list-disc space-y-2 pl-5 text-gray-700 font-raleway">
             {objectifs.map((item, index) => (
-              <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
+              <li key={index}>{item.content}</li>
             ))}
           </ul>
         </div>
@@ -207,9 +207,7 @@ const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
           <ul className="list-disc space-y-3 pl-5 text-gray-700 font-raleway">
             {actions.map((item, index) => {
               if (!item.link) {
-                return (
-                  <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
-                );
+                return <li key={index}>{item.content}</li>;
               }
 
               const LinkIcon = item.linkIcon ?? ArrowRight;
@@ -218,7 +216,7 @@ const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
               return (
                 <li key={index}>
                   <div className="flex flex-wrap items-center gap-2">
-                    <span dangerouslySetInnerHTML={{ __html: item.text }}></span>
+                    <span className="text-gray-700">{item.content}</span>
                     <Link
                       to={item.link}
                       className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:text-french-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue"
@@ -241,7 +239,7 @@ const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
           <h4 className="mb-3 text-lg font-semibold text-slate-900">Indicateurs détaillés</h4>
           <ul className="list-disc space-y-2 pl-5 text-gray-700 font-raleway">
             {indicators.map((item, index) => (
-              <li key={index} dangerouslySetInnerHTML={{ __html: item.text }}></li>
+              <li key={index}>{item.content}</li>
             ))}
           </ul>
         </div>

--- a/src/components/PSDAxeTransversal.tsx
+++ b/src/components/PSDAxeTransversal.tsx
@@ -7,33 +7,42 @@ const PSDAxeTransversal = () => {
   const focusAreas = [
     {
       title: 'Préservation du patrimoine bâti',
-      description:
-        'Programme pluriannuel de rénovation des façades et espaces intérieurs pour garantir des lieux d\'apprentissage durables.'
+      description: (
+        <>Programme pluriannuel de rénovation des façades et espaces intérieurs pour garantir des lieux d'apprentissage durables.</>
+      )
     },
     {
       title: 'Modernisation des équipements numériques',
-      description:
-        'Renouvellement planifié du parc informatique et des infrastructures réseau pour soutenir les usages pédagogiques.'
+      description: (
+        <>Renouvellement planifié du parc informatique et des infrastructures réseau pour soutenir les usages pédagogiques.</>
+      )
     },
     {
       title: 'Confort acoustique et bien-être',
-      description:
-        'Installation progressive de solutions acoustiques afin d\'offrir un environnement serein et propice aux apprentissages.'
+      description: (
+        <>Installation progressive de solutions acoustiques afin d'offrir un environnement serein et propice aux apprentissages.</>
+      )
     }
   ];
 
   const roadmap = [
     {
       period: '2025',
-      detail: 'Lancement opérationnel du plan et programmation budgétaire des premiers travaux structurants.'
+      detail: (
+        <>Lancement opérationnel du plan et programmation budgétaire des premiers travaux structurants.</>
+      )
     },
     {
       period: '2026-2028',
-      detail: 'Déploiement coordonné des trois volets (bâti, numérique, acoustique) avec suivi trimestriel.'
+      detail: (
+        <>Déploiement coordonné des trois volets (bâti, numérique, acoustique) avec suivi trimestriel.</>
+      )
     },
     {
       period: '2029-2030',
-      detail: 'Évaluations d\'impact, ajustements et pérennisation des investissements réalisés.'
+      detail: (
+        <>Évaluations d'impact, ajustements et pérennisation des investissements réalisés.</>
+      )
     }
   ];
 


### PR DESCRIPTION
## Summary
- allow PSD axe layout items to accept React nodes and render them directly
- rewrite axe content definitions as JSX fragments to preserve formatting without `dangerouslySetInnerHTML`
- express transversal maintenance descriptions and roadmap details as React nodes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d86c1aa8d48331b6ee0eff4ec26e93