### PR TITLE
Add axis keywords to PSD tabs

### DIFF
--- a/src/components/PSDTabs.tsx
+++ b/src/components/PSDTabs.tsx
@@ -17,35 +17,49 @@ const PSDTabs = () => {
           className="group flex flex-col items-center justify-center basis-1/2 sm:basis-1/3 lg:basis-1/5 px-3 py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
         >
           <Target className="mb-1 h-5 w-5 sm:h-6 sm:w-6 lg:h-8 lg:w-8 transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]" />
-          <span className="block text-xs sm:text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 1</span>
+          <div className="mt-1 flex flex-col items-center gap-0.5 text-center">
+            <span className="block text-xs sm:text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 1</span>
+            <span className="text-xs text-muted-foreground">Bien-être</span>
+          </div>
         </TabsTrigger>
         <TabsTrigger
           value="axe2"
           className="group flex flex-col items-center justify-center basis-1/2 sm:basis-1/3 lg:basis-1/5 px-3 py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
         >
           <Users className="mb-1 h-5 w-5 sm:h-6 sm:w-6 lg:h-8 lg:w-8 transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]" />
-          <span className="block text-xs sm:text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 2</span>
+          <div className="mt-1 flex flex-col items-center gap-0.5 text-center">
+            <span className="block text-xs sm:text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 2</span>
+            <span className="text-xs text-muted-foreground">Ouverture</span>
+          </div>
         </TabsTrigger>
         <TabsTrigger
           value="axe3"
           className="group flex flex-col items-center justify-center basis-1/2 sm:basis-1/3 lg:basis-1/5 px-3 py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
         >
           <Sparkles className="mb-1 h-5 w-5 sm:h-6 sm:w-6 lg:h-8 lg:w-8 transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]" />
-          <span className="block text-xs sm:text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 3</span>
+          <div className="mt-1 flex flex-col items-center gap-0.5 text-center">
+            <span className="block text-xs sm:text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 3</span>
+            <span className="text-xs text-muted-foreground">Innovation</span>
+          </div>
         </TabsTrigger>
         <TabsTrigger
           value="axe4"
           className="group flex flex-col items-center justify-center basis-1/2 sm:basis-1/3 lg:basis-1/5 px-3 py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
         >
           <GraduationCap className="mb-1 h-5 w-5 sm:h-6 sm:w-6 lg:h-8 lg:w-8 transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]" />
-          <span className="block text-xs sm:text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 4</span>
+          <div className="mt-1 flex flex-col items-center gap-0.5 text-center">
+            <span className="block text-xs sm:text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Axe 4</span>
+            <span className="text-xs text-muted-foreground">Réussite</span>
+          </div>
         </TabsTrigger>
         <TabsTrigger
           value="axe5"
           className="group flex flex-col items-center justify-center basis-1/2 sm:basis-1/3 lg:basis-1/5 px-3 py-3 text-center text-[#333333] transition duration-200 data-[state=active]:text-[#005BAC]"
         >
           <LayoutDashboard className="mb-1 h-5 w-5 sm:h-6 sm:w-6 lg:h-8 lg:w-8 transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]" />
-          <span className="block text-xs sm:text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Transversal</span>
+          <div className="mt-1 flex flex-col items-center gap-0.5 text-center">
+            <span className="block text-xs sm:text-sm md:text-lg transition duration-200 group-hover:scale-[1.15] group-hover:text-[#005BAC]">Transversal</span>
+          </div>
         </TabsTrigger>
       </TabsList>
       


### PR DESCRIPTION
## Summary
- add subtitle keywords for axes 1 à 4 in the PSD tabs component
- wrap each tab label in a vertical stack to align two-line layout while keeping the transversal label unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d942729eac8331822e73b073656e52