### PR TITLE
Update PSD axe 4 actions

### DIFF
--- a/src/components/PSDAxe4.tsx
+++ b/src/components/PSDAxe4.tsx
@@ -62,19 +62,20 @@ const PSDAxe4 = () => {
     {
       content: (
         <>
-          <strong>Valorisation de l'erreur et de la persévérance</strong> :
-          <br />• <strong>Pédagogies explicites</strong> sur l'erreur constructive
-          <br />• <strong>Interventions d'anciens élèves</strong> autour de leurs parcours
-          <br />• Programme « <strong>Cultiver l'audace</strong> » valorisant les initiatives étudiantes
+          <strong>Valorisation de l'erreur et de la persévérance</strong> :{' '}
+          <strong>Pédagogies explicites</strong> sur l'erreur constructive, <strong>interventions d'anciens élèves</strong> autour
+          de leurs parcours et programme « <strong>Cultiver l'audace</strong> » valorisant les initiatives étudiantes
         </>
       ),
+      link: '/valorisation-erreur-perseverance',
+      linkAriaLabel: "Découvrir le programme Valorisation de l'erreur et de la persévérance",
     },
     {
       content: (
         <>
-          <strong>Parcours de la Réussite citoyenne</strong> :
-          <br />• <strong>Projets solidaires et participatifs</strong> (ex. budgets participatifs)
-          <br />• Modules de formation à l'<strong>engagement citoyen</strong>
+          <strong>Parcours de la Réussite citoyenne</strong> :{' '}
+          <strong>projets solidaires et participatifs</strong> (ex. budgets participatifs) — modules de formation à
+          l'<strong>engagement citoyen</strong>
         </>
       ),
     },


### PR DESCRIPTION
## Summary
- rewrite the "Parcours de la Réussite citoyenne" action description on a single line
- add navigation metadata to the "Valorisation de l'erreur et de la persévérance" action so PSDAxeLayout renders its CTA

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d95a56da508331b80a0a9a3e038221