### PR TITLE
Add link to Réussite citoyenne pathway in axe 4

### DIFF
--- a/src/components/PSDAxe4.tsx
+++ b/src/components/PSDAxe4.tsx
@@ -71,13 +71,9 @@ const PSDAxe4 = () => {
       linkAriaLabel: "Découvrir le programme Valorisation de l'erreur et de la persévérance",
     },
     {
-      content: (
-        <>
-          <strong>Parcours de la Réussite citoyenne</strong> :{' '}
-          <strong>projets solidaires et participatifs</strong> (ex. budgets participatifs) — modules de formation à
-          l'<strong>engagement citoyen</strong>
-        </>
-      ),
+      content: <strong>Parcours de la Réussite citoyenne</strong>,
+      link: '/plan-strategique/reussite-citoyenne',
+      linkAriaLabel: 'Découvrir le parcours Réussite citoyenne',
     },
     {
       content: (


### PR DESCRIPTION
## Summary
- simplify the Axe 4 citizen success action content to only show the pathway title
- wire the action to the new Réussite citoyenne page with proper accessibility label so the layout renders the call to action button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95bacf8d88331bb1c715840586b7b