### PR TITLE
Rend le fil d'Ariane récursif et ajoute l'entrée Axe 4

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -33,8 +33,22 @@ const BreadcrumbNav = () => {
   if (!currentRoute) return null;
 
   // Si la route a un parent, on l'affiche dans le breadcrumb
-  const parentPath = currentRoute.parent;
-  const parentRoute = parentPath ? routes[parentPath] : null;
+  const ancestors: { path: string; name: string }[] = [];
+  const visitedPaths = new Set<string>();
+  let parentPath = currentRoute.parent;
+
+  while (parentPath && !visitedPaths.has(parentPath)) {
+    visitedPaths.add(parentPath);
+    const parentRoute = routes[parentPath];
+
+    if (!parentRoute) break;
+
+    if (parentPath !== "/") {
+      ancestors.unshift({ path: parentPath, name: parentRoute.name });
+    }
+
+    parentPath = parentRoute.parent;
+  }
 
   return (
     <div className="bg-gray-50 py-2 px-6 border-b animate-fade-in">
@@ -49,18 +63,18 @@ const BreadcrumbNav = () => {
             </BreadcrumbLink>
           </BreadcrumbItem>
           
-          {parentRoute && parentPath !== "/" && (
-            <>
+          {ancestors.map(({ path, name }) => (
+            <React.Fragment key={path}>
               <BreadcrumbSeparator />
               <BreadcrumbItem>
                 <BreadcrumbLink asChild>
-                  <Link to={parentPath} className="text-french-blue hover:underline">
-                    {parentRoute.name}
+                  <Link to={path} className="text-french-blue hover:underline">
+                    {name}
                   </Link>
                 </BreadcrumbLink>
               </BreadcrumbItem>
-            </>
-          )}
+            </React.Fragment>
+          ))}
           
           <BreadcrumbSeparator />
           

--- a/src/data/breadcrumbRoutes.json
+++ b/src/data/breadcrumbRoutes.json
@@ -24,6 +24,10 @@
     "name": "PC par Lycéen",
     "parent": "/plan-strategique"
   },
+  "/plan-strategique/axe-4": {
+    "name": "Axe 4",
+    "parent": "/plan-strategique"
+  },
   "/mecenat-numerique": {
     "name": "Mécénat numérique",
     "parent": "/plan-strategique"

--- a/tests/breadcrumbRoutes.test.mjs
+++ b/tests/breadcrumbRoutes.test.mjs
@@ -9,6 +9,7 @@ const expectedRoutes = {
   '/curriculum-soft-skills': { parent: '/plan-strategique' },
   '/section-internationale-bfi': { parent: '/plan-strategique' },
   '/pc-par-lyceen': { parent: '/plan-strategique' },
+  '/plan-strategique/axe-4': { parent: '/plan-strategique' },
   '/mecenat-numerique': { parent: '/plan-strategique' },
   '/construction-cantine': { parent: '/plan-strategique' },
   '/protocole-phare': { parent: '/plan-strategique' },
@@ -36,4 +37,48 @@ test('les routes racines sont présentes', () => {
   assert.ok(routes['/'], 'La route racine "/" doit être définie.');
   assert.ok(routes['/plan-strategique'], 'La page plan stratégique doit être définie.');
   assert.ok(routes['/diagnostic'], 'La page diagnostic doit être définie.');
+});
+
+test('la page Axe 4 est définie dans le plan stratégique', () => {
+  const axe4 = routes['/plan-strategique/axe-4'];
+  assert.ok(axe4, 'La route "/plan-strategique/axe-4" doit être définie.');
+  assert.strictEqual(
+    axe4.parent,
+    '/plan-strategique',
+    'La page Axe 4 doit avoir pour parent "/plan-strategique".'
+  );
+});
+
+test('les routes peuvent chaîner plusieurs parents jusqu\'à la racine', () => {
+  const targetPath = '/curriculum-soft-skills';
+  let currentPath = targetPath;
+  const visited = new Set([currentPath]);
+  let reachedRoot = false;
+
+  while (true) {
+    const route = routes[currentPath];
+    assert.ok(route, `La route "${currentPath}" doit être définie.`);
+
+    const parent = route.parent;
+    if (!parent) break;
+
+    if (parent === '/') {
+      reachedRoot = true;
+      assert.ok(routes[parent], 'La route racine "/" doit être définie.');
+      break;
+    }
+
+    assert.ok(
+      !visited.has(parent),
+      `La hiérarchie des routes ne doit pas contenir de cycle (boucle détectée à "${parent}").`
+    );
+
+    visited.add(parent);
+    currentPath = parent;
+  }
+
+  assert.ok(
+    reachedRoot,
+    `La route "${targetPath}" doit pouvoir remonter jusqu'à la racine "/" en suivant ses parents.`
+  );
 });


### PR DESCRIPTION
## Summary
- construit récursivement la hiérarchie des parents pour le fil d'Ariane afin de rendre chaque segment cliquable
- ajoute la route Axe 4 au plan stratégique dans les données du fil d'Ariane
- étend la couverture de tests pour vérifier la nouvelle entrée et la remontée jusqu'à la racine

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d95badca5483319b418347ffbf5efa