### PR TITLE
Remove extra curriculum descriptor

### DIFF
--- a/src/components/PSDAxe4.tsx
+++ b/src/components/PSDAxe4.tsx
@@ -52,8 +52,7 @@ const PSDAxe4 = () => {
     {
       content: (
         <>
-          <strong>Curriculum vertical « Soft Skills & Éloquence »</strong> : parcours PS → Terminale structurant prise de
-          parole, estime de soi, techniques oratoires et leadership.
+          <strong>Curriculum vertical « Soft Skills & Éloquence »</strong>
         </>
       ),
       link: '/curriculum-soft-skills',


### PR DESCRIPTION
## Summary
- remove the descriptive sentence appended to the Soft Skills & Éloquence curriculum action item

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9659452188331991f68d38a38e94e