### PR TITLE
Simplify Plan Stratégique navigation

### DIFF
--- a/src/components/navigation/DesktopMenu.tsx
+++ b/src/components/navigation/DesktopMenu.tsx
@@ -1,27 +1,19 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import {
   NavigationMenu,
   NavigationMenuList,
-  NavigationMenuItem,
-  NavigationMenuTrigger,
-  NavigationMenuContent,
-  NavigationMenuLink,
 } from "@/components/ui/navigation-menu";
 import DesktopNavItem from './DesktopNavItem';
-import { cn } from '@/lib/utils';
 
 interface DesktopMenuProps {
   isActive: (path: string) => boolean;
 }
 
 const DesktopMenu = ({ isActive }: DesktopMenuProps) => {
-  const isPlanStrategiqueActive = isActive('/plan-strategique');
-
   return (
     <NavigationMenu className="hidden md:flex">
       <NavigationMenuList className="space-x-2">
-        <DesktopNavItem to="/" isActive={isActive('/')}>
+        <DesktopNavItem to="/" isActive={isActive('/')}> 
           Accueil
         </DesktopNavItem>
 
@@ -33,42 +25,9 @@ const DesktopMenu = ({ isActive }: DesktopMenuProps) => {
           Diagnostic
         </DesktopNavItem>
 
-        <NavigationMenuItem>
-          <NavigationMenuTrigger
-            className={cn(
-              "font-raleway transition-colors duration-200",
-              isPlanStrategiqueActive
-                ? 'bg-french-blue text-white data-[state=open]:bg-french-blue data-[state=open]:text-white'
-                : 'hover:bg-blue-50 hover:text-french-blue'
-            )}
-          >
-            Plan Stratégique
-          </NavigationMenuTrigger>
-          <NavigationMenuContent className="rounded-xl border border-blue-100 bg-white p-4 shadow-lg">
-            <div className="grid w-[280px] gap-3">
-              <NavigationMenuLink asChild>
-                <Link
-                  to="/plan-strategique"
-                  className="block rounded-lg border border-transparent bg-white px-4 py-3 text-sm font-semibold text-slate-800 transition hover:border-french-blue/40 hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-french-blue"
-                >
-                  Vue d'ensemble du plan
-                </Link>
-              </NavigationMenuLink>
-
-              <NavigationMenuLink asChild>
-                <Link
-                  to="/plan-strategique/reussite-citoyenne"
-                  className="block rounded-lg border border-transparent bg-blue-50/70 px-4 py-3 text-sm font-semibold text-french-blue transition hover:border-french-blue/50 hover:bg-blue-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-french-blue"
-                >
-                  Axe 4 – Réussite citoyenne
-                  <span className="mt-1 block text-xs font-normal text-slate-600">
-                    Former des citoyens libres, responsables et solidaires
-                  </span>
-                </Link>
-              </NavigationMenuLink>
-            </div>
-          </NavigationMenuContent>
-        </NavigationMenuItem>
+        <DesktopNavItem to="/plan-strategique" isActive={isActive('/plan-strategique')}>
+          Plan Stratégique
+        </DesktopNavItem>
 
       </NavigationMenuList>
     </NavigationMenu>

--- a/src/components/navigation/MobileMenu.tsx
+++ b/src/components/navigation/MobileMenu.tsx
@@ -61,18 +61,6 @@ const MobileMenu = ({ id, mobileMenuOpen, setMobileMenuOpen, isActive }: MobileM
           Plan Stratégique
         </MobileNavItem>
 
-        <div className="ml-2 mt-1 border-l border-blue-100 pl-3">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Axe 4</p>
-          <MobileNavItem
-            to="/plan-strategique/reussite-citoyenne"
-            isActive={isActive('/plan-strategique/reussite-citoyenne')}
-            onClick={() => setMobileMenuOpen(false)}
-            className="mt-2 pl-4 text-sm"
-          >
-            Réussite citoyenne
-          </MobileNavItem>
-        </div>
-
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- revert the desktop "Plan Stratégique" menu entry to a simple link without the Axe 4 dropdown
- remove the Axe 4 shortcut from the mobile navigation drawer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9676439c083318c5085fb16cf383e