### PR TITLE
Persist strategic plan tab selection

### DIFF
--- a/src/pages/CurriculumSoftSkills.tsx
+++ b/src/pages/CurriculumSoftSkills.tsx
@@ -156,7 +156,7 @@ const CurriculumSoftSkills = () => {
 
       <div className="container mx-auto px-6 py-6 flex flex-wrap gap-3">
         <Button variant="outline" asChild>
-          <Link to="/plan-strategique">
+          <Link to="/plan-strategique" state={{ axe: 'axe4' }}>
             <ArrowLeft className="mr-2 h-4 w-4" />
             Retour au plan stratégique
           </Link>

--- a/src/pages/MecenatNumerique.tsx
+++ b/src/pages/MecenatNumerique.tsx
@@ -144,7 +144,7 @@ const MecenatNumerique = () => {
 
       <div className="container mx-auto px-6 py-6 flex flex-wrap gap-3">
         <Button variant="outline" asChild>
-          <Link to="/plan-strategique">
+          <Link to="/plan-strategique" state={{ axe: 'axe4' }}>
             <ArrowLeft className="mr-2 h-4 w-4" />
             Retour au plan stratégique
           </Link>

--- a/src/pages/PCParLyceen.tsx
+++ b/src/pages/PCParLyceen.tsx
@@ -49,7 +49,7 @@ const PCParLyceen = () => {
       <div className="container mx-auto px-6 py-12">
         <div className="flex flex-wrap gap-4 mb-8 items-center justify-center sm:justify-start">
           <Button variant="outline" asChild>
-            <Link to="/plan-strategique">
+            <Link to="/plan-strategique" state={{ axe: 'axe4' }}>
               <ArrowLeft className="mr-2" />
               Retour au plan stratégique
             </Link>


### PR DESCRIPTION
## Summary
- make the PSD tabs controlled, persisting the active axis in session storage and honoring state/query overrides
- ensure detail pages link back to the strategic plan with the originating axis preselected

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d96dfd1d5c8331a2242a566bfc3566