### PR TITLE
Fix apostrophe escape characters in French content

### DIFF
--- a/src/components/PSDAxeTransversal.tsx
+++ b/src/components/PSDAxeTransversal.tsx
@@ -71,7 +71,7 @@ const PSDAxeTransversal = () => {
             </div>
 
             <p className="text-base md:text-lg font-raleway text-white/90">
-              Un dispositif global qui articule les investissements immobiliers, numériques et acoustiques afin d\'assurer la pérennité du lycée et la qualité d\'accueil de toute la communauté éducative.
+              Un dispositif global qui articule les investissements immobiliers, numériques et acoustiques afin d’assurer la pérennité du lycée et la qualité d’accueil de toute la communauté éducative.
             </p>
 
             <ul className="space-y-4">
@@ -104,7 +104,7 @@ const PSDAxeTransversal = () => {
         <article className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
           <h4 className="text-lg font-semibold text-slate-900">Feuille de route 2025-2030</h4>
           <p className="mt-2 text-sm text-slate-600">
-            Un pilotage rigoureux du plan garantit une mise en œuvre progressive, évaluée et partagée avec l\'ensemble des parties prenantes.
+            Un pilotage rigoureux du plan garantit une mise en œuvre progressive, évaluée et partagée avec l’ensemble des parties prenantes.
           </p>
 
           <ol className="mt-6 space-y-4">

--- a/src/components/diagnostic/restaurant/restaurantData.ts
+++ b/src/components/diagnostic/restaurant/restaurantData.ts
@@ -21,7 +21,7 @@ export const currentLunchData = [
   { name: 'À la maison ou chez un proche', value: 28, percentage: 35 },
   { name: 'Un repas préparé à la maison (lunch-box)', value: 35, percentage: 43.8 },
   { name: 'Un plat ou repas livré', value: 25, percentage: 31.3 },
-  { name: 'Un repas acheté à proximité de l\'établissement', value: 36, percentage: 45 },
+  { name: 'Un repas acheté à proximité de l’établissement', value: 36, percentage: 45 },
   { name: 'À la maison et un repas préparé', value: 1, percentage: 1.3 }
 ];
 

--- a/src/pages/EducationFinanciereVieAutonome.tsx
+++ b/src/pages/EducationFinanciereVieAutonome.tsx
@@ -9,7 +9,7 @@ const PAGE_TITLE = 'Éducation financière et à la vie autonome | PSD LFJP';
 
 const programmePiliers = [
   {
-    title: 'Mise en place d\'EDUCFI',
+    title: 'Mise en place d’EDUCFI',
     description:
       "Déploiement du référentiel Éducation Économique, Budgétaire et Financière (EDUCFI) en partenariat avec des acteurs locaux et l'Ambassade de France.",
     icon: GraduationCap,
@@ -38,7 +38,7 @@ const parcoursEtudiants = [
     ],
   },
   {
-    title: 'Pendant l\'installation',
+    title: 'Pendant l’installation',
     points: [
       'Ateliers en visioconférence sur l’ouverture d’un compte bancaire, les assurances obligatoires et la gestion des aides.',
       'Accompagnement à la compréhension des contrats de logement, bourses CROUS et mutuelles étudiantes.',
@@ -92,7 +92,7 @@ const EducationFinanciereVieAutonome = () => {
               Éducation financière et à la vie autonome
             </h1>
             <p className="mt-6 max-w-3xl text-base text-blue-50 md:text-lg">
-              Nous accompagnons nos lycéens dans la mise en place du programme EDUCFI et dans l\'appropriation des codes de la vie étudiante en France afin de sécuriser leur réussite post-bac.
+              Nous accompagnons nos lycéens dans la mise en place du programme EDUCFI et dans l’appropriation des codes de la vie étudiante en France afin de sécuriser leur réussite post-bac.
             </p>
           </div>
         </section>
@@ -138,7 +138,7 @@ const EducationFinanciereVieAutonome = () => {
                 Un parcours guidé pour les élèves poursuivant leurs études en France
               </h2>
               <p className="mt-4 text-base leading-relaxed text-slate-700">
-                De la classe de seconde à l\'entrée dans l\'enseignement supérieur, chaque étape consolide l\'autonomie et la maîtrise budgétaire des élèves.
+                De la classe de seconde à l’entrée dans l’enseignement supérieur, chaque étape consolide l’autonomie et la maîtrise budgétaire des élèves.
               </p>
 
               <div className="mt-10 grid gap-8 lg:grid-cols-3">
@@ -168,7 +168,7 @@ const EducationFinanciereVieAutonome = () => {
               <article className="rounded-2xl border border-slate-200 bg-slate-50 p-8">
                 <h2 className="text-2xl font-playfair font-bold text-french-blue">Des ressources concrètes pour agir</h2>
                 <p className="mt-4 text-base leading-relaxed text-slate-700">
-                  Chaque séance associe mise en situation, outils numériques et retours d\'expérience afin de permettre aux futurs étudiants de se projeter sereinement dans leur nouvelle vie.
+                  Chaque séance associe mise en situation, outils numériques et retours d’expérience afin de permettre aux futurs étudiants de se projeter sereinement dans leur nouvelle vie.
                 </p>
 
                 <ul className="mt-6 space-y-4 text-sm leading-relaxed text-slate-700 md:text-base">
@@ -183,21 +183,21 @@ const EducationFinanciereVieAutonome = () => {
 
               <aside className="flex flex-col justify-between gap-6 rounded-2xl border border-blue-100 bg-blue-50/60 p-8 text-blue-900">
                 <div>
-                  <h2 className="text-lg font-semibold text-french-blue">Réseau d\'accompagnement</h2>
+                  <h2 className="text-lg font-semibold text-french-blue">Réseau d’accompagnement</h2>
                   <p className="mt-3 text-sm leading-relaxed md:text-base">
-                    Le dispositif mobilise le service orientation, les associations de parents d\'élèves et un collectif d\'alumni bénévoles pour répondre aux questions pratiques et budgétaires.
+                    Le dispositif mobilise le service orientation, les associations de parents d’élèves et un collectif d’alumni bénévoles pour répondre aux questions pratiques et budgétaires.
                   </p>
                 </div>
                 <div className="rounded-xl bg-white/80 p-5 text-sm text-slate-800 shadow-sm">
                   <p className="font-semibold uppercase tracking-wide text-french-blue">Objectif</p>
                   <p className="mt-2">
-                    Garantir que 100 % des élèves quittant le lycée disposent d\'un plan budgétaire réaliste et des ressources nécessaires pour gagner en autonomie dès leur arrivée en France.
+                    Garantir que 100 % des élèves quittant le lycée disposent d’un plan budgétaire réaliste et des ressources nécessaires pour gagner en autonomie dès leur arrivée en France.
                   </p>
                 </div>
                 <div className="rounded-xl bg-white/80 p-5 text-sm text-slate-800 shadow-sm">
                   <p className="font-semibold uppercase tracking-wide text-french-blue">Acteurs mobilisés</p>
                   <p className="mt-2">
-                    Conseillers d\'orientation, parents volontaires, partenaires bancaires et représentants d\'organismes sociaux accompagnent la montée en compétence des élèves.
+                    Conseillers d’orientation, parents volontaires, partenaires bancaires et représentants d’organismes sociaux accompagnent la montée en compétence des élèves.
                   </p>
                 </div>
               </aside>

--- a/src/pages/MecenatNumerique.tsx
+++ b/src/pages/MecenatNumerique.tsx
@@ -25,9 +25,9 @@ const responsables = [
 ];
 
 const calendrier = [
-  '2026 : Création du fonds et élaboration de la charte d\'utilisation.',
+  '2026 : Création du fonds et élaboration de la charte d’utilisation.',
   '2026-2027 : Lancement des premiers appels à mécénat et partenariats locaux/internationaux.',
-  '2027-2028 : Premiers financements d\'équipements et modules de formation.',
+  '2027-2028 : Premiers financements d’équipements et modules de formation.',
   '2029-2030 : Extension et consolidation du fonds, bilan et pérennisation dans le budget LFJP.'
 ];
 
@@ -48,7 +48,7 @@ const actionsPrevues = [
 const parcoursEducatifs = [
   {
     title: 'Parcours Avenir',
-    description: 'Découverte des métiers du numérique et de l\'innovation.'
+    description: 'Découverte des métiers du numérique et de l’innovation.'
   },
   {
     title: 'Parcours Citoyen',
@@ -65,8 +65,8 @@ const parcoursEducatifs = [
 ];
 
 const indicateurs = [
-  '% d\'élèves équipés par niveau.',
-  'Nombre d\'enseignants et d\'élèves formés chaque année.',
+  '% d’élèves équipés par niveau.',
+  'Nombre d’enseignants et d’élèves formés chaque année.',
   'Montant annuel levé par mécénat et partenariats.',
   'Nombre de projets pédagogiques numériques financés.',
   'Taux de satisfaction enseignants/élèves (enquêtes annuelles).'
@@ -74,19 +74,19 @@ const indicateurs = [
 
 const perennisation = [
   'Inscription du fonds dans le budget prévisionnel du LFJP.',
-  'Développement d\'un réseau de mécènes durables.',
+  'Développement d’un réseau de mécènes durables.',
   'Valorisation annuelle auprès de la communauté éducative et des partenaires.'
 ];
 
 const ficheTable = [
   {
-    label: 'Intitulé de l\'action',
-    value: 'Développement d\'un fonds de soutien ou mécénat numérique pour l\'équipement et la formation'
+    label: 'Intitulé de l’action',
+    value: 'Développement d’un fonds de soutien ou mécénat numérique pour l’équipement et la formation'
   },
   {
     label: 'Objectif stratégique',
     value:
-      'Garantir l\'équité d\'accès aux outils numériques, soutenir l\'innovation pédagogique et renforcer les compétences numériques des élèves et personnels.'
+      'Garantir l’équité d’accès aux outils numériques, soutenir l’innovation pédagogique et renforcer les compétences numériques des élèves et personnels.'
   },
   {
     label: 'Responsables',
@@ -96,7 +96,7 @@ const ficheTable = [
   {
     label: 'Calendrier',
     value:
-      '2026 : création du fonds et charte d\'utilisation • 2026-2027 : lancement des appels à mécénat et partenariats • 2027-2028 : premiers financements (équipements, formations) • 2029-2030 : extension, consolidation et bilan.'
+      '2026 : création du fonds et charte d’utilisation • 2026-2027 : lancement des appels à mécénat et partenariats • 2027-2028 : premiers financements (équipements, formations) • 2029-2030 : extension, consolidation et bilan.'
   },
   {
     label: 'Moyens mobilisés',
@@ -111,12 +111,12 @@ const ficheTable = [
   {
     label: 'Articulation parcours éducatifs',
     value:
-      'Parcours Avenir : métiers du numérique et de l\'innovation • Parcours Citoyen : éducation aux médias, citoyenneté numérique • Parcours Santé : prévention des usages excessifs, équilibre numérique • PEAC : projets artistiques et créatifs numériques.'
+      'Parcours Avenir : métiers du numérique et de l’innovation • Parcours Citoyen : éducation aux médias, citoyenneté numérique • Parcours Santé : prévention des usages excessifs, équilibre numérique • PEAC : projets artistiques et créatifs numériques.'
   },
   {
     label: 'Indicateurs de suivi',
     value:
-      '% d\'élèves équipés • Nombre d\'enseignants et d\'élèves formés/an • Montant levé par mécénat et partenariats • Nombre de projets pédagogiques numériques financés • Taux de satisfaction enseignants/élèves (enquêtes annuelles).'
+      '% d’élèves équipés • Nombre d’enseignants et d’élèves formés/an • Montant levé par mécénat et partenariats • Nombre de projets pédagogiques numériques financés • Taux de satisfaction enseignants/élèves (enquêtes annuelles).'
   },
   {
     label: 'Perspectives de pérennisation',
@@ -136,7 +136,7 @@ const MecenatNumerique = () => {
             Mécénat numérique
           </h1>
           <p className="text-lg md:text-xl max-w-3xl font-light">
-            Un fonds dédié pour garantir l\'équité d\'accès aux outils numériques, soutenir l\'innovation
+            Un fonds dédié pour garantir l’équité d’accès aux outils numériques, soutenir l’innovation
             pédagogique et développer les compétences de toute la communauté éducative.
           </p>
         </div>
@@ -164,12 +164,12 @@ const MecenatNumerique = () => {
               <Lightbulb className="h-6 w-6 text-amber-500" aria-hidden="true" />
               <div>
                 <CardTitle>Objectif stratégique</CardTitle>
-                <CardDescription>Cap vers l\'innovation et l\'équité numérique</CardDescription>
+                <CardDescription>Cap vers l’innovation et l’équité numérique</CardDescription>
               </div>
             </CardHeader>
             <CardContent>
               <p className="leading-relaxed text-gray-700">
-                Garantir l\'équité d\'accès aux outils numériques, soutenir l\'innovation pédagogique et renforcer
+                Garantir l’équité d’accès aux outils numériques, soutenir l’innovation pédagogique et renforcer
                 les compétences numériques des élèves et des personnels, en mobilisant des financements
                 complémentaires aux écolages.
               </p>


### PR DESCRIPTION
## Summary
- replace escaped apostrophes with typographic apostrophes so French copy no longer shows stray backslashes
- update diagnostic data labels and PSD pages to consistently use the same apostrophe style

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9736414ac8331ae35ae4b73e09fc6