### PR TITLE
feat: enrichir la page réseau alumni et mentorat

### DIFF
--- a/src/pages/ReseauAlumniMentorat.tsx
+++ b/src/pages/ReseauAlumniMentorat.tsx
@@ -3,7 +3,15 @@ import { Link, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
-import { ArrowLeft, Home, Construction } from 'lucide-react';
+import {
+  ArrowLeft,
+  Home,
+  Users,
+  GraduationCap,
+  Globe2,
+  CalendarClock,
+  Sparkles,
+} from 'lucide-react';
 
 const ReseauAlumniMentorat = () => {
   const navigate = useNavigate();
@@ -22,7 +30,9 @@ const ReseauAlumniMentorat = () => {
               Réseau d'alumni et mentorat
             </h1>
             <p className="mt-4 max-w-2xl text-base md:text-lg text-blue-100">
-              Cette rubrique est en cours de construction. Revenez prochainement pour découvrir le détail du dispositif.
+              Le Lycée Français Jacques Prévert souhaite maintenir un lien fort avec
+              ses anciens élèves, valoriser leurs parcours et offrir aux lycéens
+              actuels un réseau d&apos;appui, d&apos;inspiration et de mentorat.
             </p>
           </div>
         </div>
@@ -43,17 +53,149 @@ const ReseauAlumniMentorat = () => {
             </Button>
           </div>
 
-          <div className="mt-12 flex flex-col items-center justify-center rounded-3xl border border-dashed border-french-blue/40 bg-white/70 p-10 text-center shadow-sm">
-            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-french-blue/10 text-french-blue">
-              <Construction className="h-8 w-8" aria-hidden />
+          <section className="mt-12 grid gap-12">
+            <div className="rounded-3xl bg-white/80 p-8 shadow-sm ring-1 ring-slate-200/70">
+              <div className="flex items-start gap-4">
+                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-french-blue/10 text-french-blue">
+                  <Users className="h-7 w-7" aria-hidden />
+                </div>
+                <div>
+                  <h2 className="text-2xl font-playfair font-semibold text-slate-900">
+                    Base de données des anciens élèves
+                  </h2>
+                  <p className="mt-3 text-slate-600">
+                    Mise en place d&apos;un annuaire digital sécurisé pour rassembler les
+                    parcours des alumni et faciliter les connexions entre
+                    générations.
+                  </p>
+                  <ul className="mt-4 space-y-2 text-sm text-slate-600 md:text-base">
+                    <li>• Collecte d&apos;informations : études, expériences professionnelles, pays de résidence.</li>
+                    <li>• Outil collaboratif pour activer une communauté solidaire et accessible.</li>
+                    <li>• Mise en relation simplifiée pour les projets pédagogiques et professionnels.</li>
+                  </ul>
+                </div>
+              </div>
             </div>
-            <h2 className="mt-6 text-2xl font-playfair font-semibold text-slate-900">
-              Page en construction
-            </h2>
-            <p className="mt-3 max-w-xl text-sm md:text-base text-slate-600">
-              Nos équipes travaillent à la mise en place du réseau d'alumni et du programme de mentorat. Cette page sera bientôt mise à jour avec les informations complètes.
-            </p>
-          </div>
+
+            <div className="rounded-3xl bg-white/80 p-8 shadow-sm ring-1 ring-slate-200/70">
+              <div className="flex items-start gap-4">
+                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-french-blue/10 text-french-blue">
+                  <GraduationCap className="h-7 w-7" aria-hidden />
+                </div>
+                <div>
+                  <h2 className="text-2xl font-playfair font-semibold text-slate-900">
+                    Mentorat lycéens / alumni
+                  </h2>
+                  <p className="mt-3 text-slate-600">
+                    Un programme de parrainage pour accompagner l&apos;orientation et
+                    les projets des lycéens, nourri par l&apos;expérience des anciens
+                    élèves.
+                  </p>
+                  <ul className="mt-4 space-y-2 text-sm text-slate-600 md:text-base">
+                    <li>• Parrainage individuel ou en petit groupe pour l&apos;orientation et les premières expériences professionnelles.</li>
+                    <li>• Ateliers, témoignages et visioconférences thématiques animés par les alumni.</li>
+                    <li>• Plateforme de mise en relation encadrée par l&apos;établissement.</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-3xl bg-white/80 p-8 shadow-sm ring-1 ring-slate-200/70">
+              <div className="flex items-start gap-4">
+                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-french-blue/10 text-french-blue">
+                  <Globe2 className="h-7 w-7" aria-hidden />
+                </div>
+                <div>
+                  <h2 className="text-2xl font-playfair font-semibold text-slate-900">
+                    Les Oiseaux de Passage
+                  </h2>
+                  <p className="mt-3 text-slate-600">
+                    Un rendez-vous éditorial pour mettre en lumière la diversité des
+                    parcours et renforcer le sentiment d&apos;appartenance.
+                  </p>
+                  <ul className="mt-4 space-y-2 text-sm text-slate-600 md:text-base">
+                    <li>• Rubrique dédiée dans le Petit Prévert et sur les réseaux sociaux du lycée.</li>
+                    <li>• Mini-interviews d&apos;anciens élèves en études supérieures ou déjà insérés professionnellement.</li>
+                    <li>• Valorisation visuelle avec portraits, citations et un logo spécifique.</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-[1px]">
+              <div className="h-full rounded-[calc(1.5rem-1px)] bg-white/90 p-8">
+                <div className="flex items-start gap-4">
+                  <div className="flex h-14 w-14 items-center justify-center rounded-full bg-slate-900/5 text-slate-900">
+                    <Sparkles className="h-7 w-7" aria-hidden />
+                  </div>
+                  <div>
+                    <h2 className="text-2xl font-playfair font-semibold text-slate-900">
+                      Pistes visuelles
+                    </h2>
+                    <p className="mt-3 text-slate-600">
+                      Une identité graphique dédiée pour illustrer la dynamique du
+                      réseau.
+                    </p>
+                    <ul className="mt-4 space-y-2 text-sm text-slate-600 md:text-base">
+                      <li>• Carte interactive du monde avec la localisation des anciens élèves.</li>
+                      <li>• Portraits stylisés et citations inspirantes des alumni.</li>
+                      <li>• Création d&apos;un emblème « Les Oiseaux de Passage ».</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-3xl bg-white/80 p-8 shadow-sm ring-1 ring-slate-200/70">
+              <div className="flex items-start gap-4">
+                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-french-blue/10 text-french-blue">
+                  <CalendarClock className="h-7 w-7" aria-hidden />
+                </div>
+                <div className="w-full">
+                  <h2 className="text-2xl font-playfair font-semibold text-slate-900">
+                    Échéancier 2026-2030
+                  </h2>
+                  <p className="mt-3 text-slate-600">
+                    Un déploiement progressif sur cinq ans pour ancrer durablement le
+                    réseau d&apos;alumni et le mentorat.
+                  </p>
+                  <div className="mt-6 grid gap-6 md:grid-cols-2">
+                    <div className="rounded-2xl border border-slate-200 bg-white/90 p-5">
+                      <p className="text-sm font-semibold uppercase tracking-wide text-french-blue">
+                        Année 1
+                      </p>
+                      <p className="mt-2 text-sm text-slate-600 md:text-base">
+                        Constitution de la base de données et publication des premiers portraits.
+                      </p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-200 bg-white/90 p-5">
+                      <p className="text-sm font-semibold uppercase tracking-wide text-french-blue">
+                        Année 2
+                      </p>
+                      <p className="mt-2 text-sm text-slate-600 md:text-base">
+                        Lancement du mentorat pilote et évaluation des besoins des lycéens.
+                      </p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-200 bg-white/90 p-5">
+                      <p className="text-sm font-semibold uppercase tracking-wide text-french-blue">
+                        Années 3-4
+                      </p>
+                      <p className="mt-2 text-sm text-slate-600 md:text-base">
+                        Extension du réseau, conférences thématiques et rencontres annuelles des alumni.
+                      </p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-200 bg-white/90 p-5">
+                      <p className="text-sm font-semibold uppercase tracking-wide text-french-blue">
+                        Année 5
+                      </p>
+                      <p className="mt-2 text-sm text-slate-600 md:text-base">
+                        Structuration d&apos;un réseau autonome et durable, piloté avec les alumni.</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
         </div>
       </main>
 


### PR DESCRIPTION
## Summary
- remplacer l'état "en construction" par un contenu détaillé sur le réseau d'alumni et le mentorat
- structurer la page en sections dédiées à la base de données, au programme de mentorat, aux Oiseaux de Passage et aux pistes visuelles
- ajouter un échéancier sur cinq ans pour planifier le déploiement du dispositif

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da53ddb5588331825a4aa35b15ddc5