### PR TITLE
Add Parcours Avenir placeholder page and update Axe 4 link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import ValorisationErreur from "./pages/ValorisationErreur";
 import ReussiteCitoyenne from "./pages/plan-strategique/reussite-citoyenne";
 import EducationFinanciereVieAutonome from "./pages/EducationFinanciereVieAutonome";
 import ReseauAlumniMentorat from "./pages/ReseauAlumniMentorat";
+import ParcoursAvenir from "./pages/ParcoursAvenir";
 import BreadcrumbNav from "./components/Breadcrumb";
 import BackToTop from "./components/BackToTop";
 import ScrollToTop from "./components/ScrollToTop";
@@ -89,6 +90,13 @@ const App = () => {
                   <>
                     <BreadcrumbNav />
                     <CurriculumSoftSkills />
+                    <BackToTop />
+                  </>
+                } />
+                <Route path="/parcours-avenir" element={
+                  <>
+                    <BreadcrumbNav />
+                    <ParcoursAvenir />
                     <BackToTop />
                   </>
                 } />

--- a/src/components/PSDAxe4.tsx
+++ b/src/components/PSDAxe4.tsx
@@ -88,13 +88,9 @@ const PSDAxe4 = () => {
       linkAriaLabel: "Découvrir le projet Réseau d'alumni et mentorat",
     },
     {
-      content: (
-        <>
-          <strong>Soutien à l'orientation</strong> :
-          <br />• <strong>Accompagnement personnalisé</strong> dans le cadre du Parcours Avenir
-          <br />• <strong>Stages, forums métiers, espace orientation</strong>
-        </>
-      ),
+      content: <strong>Parcours Avenir</strong>,
+      link: '/parcours-avenir',
+      linkAriaLabel: 'Découvrir la page Parcours Avenir',
     },
   ];
   

--- a/src/data/breadcrumbRoutes.json
+++ b/src/data/breadcrumbRoutes.json
@@ -16,6 +16,10 @@
     "name": "Curriculum Soft Skills & Éloquence",
     "parent": "/plan-strategique"
   },
+  "/parcours-avenir": {
+    "name": "Parcours Avenir",
+    "parent": "/plan-strategique/axe-4"
+  },
   "/section-internationale-bfi": {
     "name": "Section Internationale et BFI",
     "parent": "/plan-strategique"

--- a/src/pages/ParcoursAvenir.tsx
+++ b/src/pages/ParcoursAvenir.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft, Home, Construction } from 'lucide-react';
+
+const ParcoursAvenir = () => {
+  return (
+    <div className="min-h-screen flex flex-col font-raleway bg-slate-50">
+      <Navbar showLogo={true} />
+
+      <header className="bg-gradient-to-r from-blue-700 to-french-blue text-white py-20 md:py-28">
+        <div className="container mx-auto px-6">
+          <p className="uppercase tracking-[0.35em] text-xs md:text-sm text-white/80">
+            Plan stratégique 2026-2030 · Axe 4
+          </p>
+          <h1 className="mt-4 text-3xl md:text-5xl font-playfair font-bold">Parcours Avenir</h1>
+          <p className="mt-4 max-w-3xl text-base md:text-lg text-white/80">
+            Cette page sera prochainement enrichie pour présenter en détail le Parcours Avenir au LFJP.
+          </p>
+        </div>
+      </header>
+
+      <div className="container mx-auto px-6 py-6 flex flex-wrap gap-3">
+        <Button variant="outline" asChild>
+          <Link to="/plan-strategique" state={{ axe: 'axe4' }}>
+            <ArrowLeft className="mr-2 h-4 w-4" aria-hidden />
+            Retour au plan stratégique
+          </Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link to="/">
+            <Home className="mr-2 h-4 w-4" aria-hidden />
+            Accueil
+          </Link>
+        </Button>
+      </div>
+
+      <main className="flex-1">
+        <section className="py-12">
+          <div className="container mx-auto px-6">
+            <div className="rounded-3xl border border-dashed border-blue-200 bg-white/70 px-8 py-16 text-center shadow-sm">
+              <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-100 text-blue-700">
+                <Construction className="h-8 w-8" aria-hidden />
+              </div>
+              <h2 className="mt-6 text-2xl font-playfair font-bold text-french-blue">Page en construction</h2>
+              <p className="mt-4 text-base text-slate-600">
+                Merci de votre patience. Les contenus liés à l&apos;orientation et aux dispositifs du Parcours Avenir
+                seront bientôt disponibles.
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default ParcoursAvenir;

--- a/tests/breadcrumbRoutes.test.mjs
+++ b/tests/breadcrumbRoutes.test.mjs
@@ -14,6 +14,7 @@ const expectedRoutes = {
   '/diagnostic': { parent: '/' },
   '/plan-strategique': { parent: '/' },
   '/curriculum-soft-skills': { parent: '/plan-strategique' },
+  '/parcours-avenir': { parent: '/plan-strategique/axe-4' },
   '/section-internationale-bfi': { parent: '/plan-strategique' },
   '/pc-par-lyceen': { parent: '/plan-strategique' },
   '/plan-strategique/axe-4': { parent: '/plan-strategique' },


### PR DESCRIPTION
## Summary
- replace the Axe 4 "Soutien à l'orientation" action with a link to the new Parcours Avenir page
- create a Parcours Avenir placeholder page with standard navigation and construction notice
- register the new route in the router, breadcrumb data, and accompanying tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daccd2fe748331a2d02136af34b7b9