### PR TITLE
Align detailed rubric links and refresh icon styling

### DIFF
--- a/src/components/PSDAxe1.tsx
+++ b/src/components/PSDAxe1.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { BarChart3, ListChecks, Target, ShieldCheck, Utensils, Leaf } from 'lucide-react';
+import { BarChart3, GraduationCap, Leaf, ListChecks, ShieldCheck, Target, Utensils } from 'lucide-react';
 
 const PSDAxe1 = () => {
   const summaryCards = [
@@ -250,25 +250,37 @@ const PSDAxe1 = () => {
 
         <div id="details-actions" className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
           <h4 className="mb-3 text-lg font-semibold text-slate-900">Rubriques détaillées</h4>
-          <ul className="list-disc space-y-3 pl-5 text-gray-700 font-raleway">
+          <ul className="space-y-3 font-raleway">
             {actions.map((item, index) => {
               if (!item.link) {
-                return <li key={index}>{item.content}</li>;
+                return (
+                  <li key={index} className="text-gray-700">
+                    {item.content}
+                  </li>
+                );
               }
 
-              const IconComponent = item.linkIcon ?? ShieldCheck;
+              const IconComponent = item.linkIcon ?? GraduationCap;
 
               return (
-                <li key={index} className="space-y-2">
-                  <span className="block text-gray-700">{item.content}</span>
-                  <Link
-                    to={item.link}
-                    className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue"
-                    aria-label={item.linkAriaLabel ?? 'En savoir plus'}
-                  >
-                    <IconComponent className="h-4 w-4" aria-hidden="true" />
-                    <span>En savoir plus</span>
-                  </Link>
+                <li key={index}>
+                  <div className="flex flex-wrap items-center gap-3 sm:flex-nowrap">
+                    <div className="flex min-w-0 flex-1 items-center gap-3">
+                      <span className="text-gray-700">{item.content}</span>
+                      <span
+                        aria-hidden="true"
+                        className="hidden h-px flex-1 border-b border-dashed border-slate-300 sm:block"
+                      />
+                    </div>
+                    <Link
+                      to={item.link}
+                      className="ml-auto inline-flex shrink-0 items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue sm:ml-0 sm:self-center"
+                      aria-label={item.linkAriaLabel ?? 'En savoir plus'}
+                    >
+                      <IconComponent className="h-4 w-4" aria-hidden="true" />
+                      <span>En savoir plus</span>
+                    </Link>
+                  </div>
                 </li>
               );
             })}

--- a/src/components/PSDAxe3.tsx
+++ b/src/components/PSDAxe3.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { HandCoins, Laptop } from 'lucide-react';
 import PSDAxeLayout from './PSDAxeLayout';
 
 const PSDAxe3 = () => {
@@ -72,7 +73,9 @@ const PSDAxe3 = () => {
       content: (
         <>Élaboration du plan « <strong>Un PC par lycéen</strong> »</>
       ),
-      link: '/pc-par-lyceen'
+      link: '/pc-par-lyceen',
+      linkAriaLabel: 'En savoir plus – Un PC par lycéen',
+      linkIcon: Laptop
     },
     {
       content: <><strong>Amélioration de la connectivité</strong> sur l'ensemble du site</>
@@ -97,7 +100,8 @@ const PSDAxe3 = () => {
         </>
       ),
       link: '/mecenat-numerique',
-      linkAriaLabel: 'Consulter la fiche-action Mécénat numérique'
+      linkAriaLabel: 'Consulter la fiche-action Mécénat numérique',
+      linkIcon: HandCoins
     }
   ];
   

--- a/src/components/PSDAxe4.tsx
+++ b/src/components/PSDAxe4.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { Compass, Medal, PiggyBank, RefreshCcw, Sparkles, UsersRound } from 'lucide-react';
 import PSDAxeLayout from './PSDAxeLayout';
 
 const PSDAxe4 = () => {
@@ -57,6 +58,7 @@ const PSDAxe4 = () => {
       ),
       link: '/curriculum-soft-skills',
       linkAriaLabel: 'Découvrir le curriculum Soft Skills & Éloquence',
+      linkIcon: Sparkles,
     },
     {
       content: (
@@ -67,16 +69,19 @@ const PSDAxe4 = () => {
       link: '/valorisation-erreur-perseverance',
       linkAriaLabel:
         "Découvrir la feuille de route du programme Valorisation de l'erreur et de la persévérance",
+      linkIcon: RefreshCcw,
     },
     {
       content: <strong>Parcours de la Réussite citoyenne</strong>,
       link: '/plan-strategique/reussite-citoyenne',
       linkAriaLabel: 'Découvrir le parcours Réussite citoyenne',
+      linkIcon: Medal,
     },
     {
       content: <strong>Éducation financière et à la vie autonome</strong>,
       link: '/education-financiere-vie-autonome',
       linkAriaLabel: "En savoir plus sur l'éducation financière et la vie autonome",
+      linkIcon: PiggyBank,
     },
     {
       content: (
@@ -86,11 +91,13 @@ const PSDAxe4 = () => {
       ),
       link: '/reseau-alumni-mentorat',
       linkAriaLabel: "Découvrir le projet Réseau d'alumni et mentorat",
+      linkIcon: UsersRound,
     },
     {
       content: <strong>Parcours Avenir</strong>,
       link: '/parcours-avenir',
       linkAriaLabel: 'Découvrir la page Parcours Avenir',
+      linkIcon: Compass,
     },
   ];
   

--- a/src/components/PSDAxeLayout.tsx
+++ b/src/components/PSDAxeLayout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import type { LucideIcon } from 'lucide-react';
-import { ArrowRight, BarChart3, ListChecks, Target } from 'lucide-react';
+import { BarChart3, GraduationCap, ListChecks, Target } from 'lucide-react';
 
 interface ObjectifItem {
   content: React.ReactNode;
@@ -204,22 +204,32 @@ const PSDAxeLayout: React.FC<PSDAxeLayoutProps> = ({
           className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
         >
           <h4 className="mb-3 text-lg font-semibold text-slate-900">Rubriques détaillées</h4>
-          <ul className="list-disc space-y-3 pl-5 text-gray-700 font-raleway">
+          <ul className="space-y-3 font-raleway">
             {actions.map((item, index) => {
               if (!item.link) {
-                return <li key={index}>{item.content}</li>;
+                return (
+                  <li key={index} className="text-gray-700">
+                    {item.content}
+                  </li>
+                );
               }
 
-              const LinkIcon = item.linkIcon ?? ArrowRight;
+              const LinkIcon = item.linkIcon ?? GraduationCap;
               const ariaLabel = item.linkAriaLabel ?? 'En savoir plus';
 
               return (
                 <li key={index}>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-gray-700">{item.content}</span>
+                  <div className="flex flex-wrap items-center gap-3 sm:flex-nowrap">
+                    <div className="flex min-w-0 flex-1 items-center gap-3">
+                      <span className="text-gray-700">{item.content}</span>
+                      <span
+                        aria-hidden="true"
+                        className="hidden h-px flex-1 border-b border-dashed border-slate-300 sm:block"
+                      />
+                    </div>
                     <Link
                       to={item.link}
-                      className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:text-french-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue"
+                      className="ml-auto inline-flex shrink-0 items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-800 transition hover:bg-slate-50 hover:text-french-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-french-blue sm:ml-0 sm:self-center"
                       aria-label={ariaLabel}
                     >
                       <LinkIcon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- align the detailed rubric links to the right and add a dashed leader line between the text and button
- replace the default arrow icon with a GraduationCap icon to better reflect the educational theme
- adjust list styling so non-link items inherit the updated presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbbcf577f08331afe60a3cce2c539d