### PR TITLE
Fix PSD tab persistence when sessionStorage is unavailable

### DIFF
--- a/src/components/PSDTabs.tsx
+++ b/src/components/PSDTabs.tsx
@@ -39,8 +39,13 @@ const PSDTabs = () => {
       return undefined;
     }
 
-    const storedValue = window.sessionStorage.getItem('psd-active-axe');
-    return isValidAxe(storedValue) ? storedValue : undefined;
+    try {
+      const storedValue = window.sessionStorage.getItem('psd-active-axe');
+      return isValidAxe(storedValue) ? storedValue : undefined;
+    } catch (error) {
+      console.warn('Impossible de lire la valeur persistée de l\'onglet PSD.', error);
+      return undefined;
+    }
   }, []);
 
   const [activeAxe, setActiveAxe] = useState<AxeValue>(() => forcedAxe ?? persistedAxe ?? 'axe1');
@@ -59,7 +64,11 @@ const PSDTabs = () => {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      window.sessionStorage.setItem('psd-active-axe', activeAxe);
+      try {
+        window.sessionStorage.setItem('psd-active-axe', activeAxe);
+      } catch (error) {
+        console.warn('Impossible d\'enregistrer l\'onglet actif du PSD.', error);
+      }
     }
   }, [activeAxe]);
 


### PR DESCRIPTION
## Summary
- wrap PSD tab persistence logic in defensive try/catch blocks so storage errors no longer break the plan page

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dbc2cd5a9883318bad8f83da68975f