### PR TITLE
Retire la mention « réécriture avec scénarios » du titre

### DIFF
--- a/src/components/RenouvellementInformatiqueTabs.tsx
+++ b/src/components/RenouvellementInformatiqueTabs.tsx
@@ -137,7 +137,7 @@ const RenouvellementInformatiqueTabs: React.FC = () => {
         <div className="space-y-12 px-4 pb-12 pt-6 text-slate-900">
           <header className="space-y-4 rounded-lg bg-french-blue/5 p-6">
             <h1 className="text-3xl font-bold text-french-blue">
-              Plan de renouvellement du parc informatique (réécriture avec scénarios)
+              Plan de renouvellement du parc informatique
             </h1>
             <div className="space-y-3 text-base leading-relaxed">
               <p>


### PR DESCRIPTION
### Motivation
- Le titre affichait le suffixe `(réécriture avec scénarios)` qui alourdit l’intitulé, il est supprimé pour un libellé plus concis.

### Description
- Remplacement du texte dans `src/components/RenouvellementInformatiqueTabs.tsx` en modifiant le contenu de la balise `h1` de `Plan de renouvellement du parc informatique (réécriture avec scénarios)` à `Plan de renouvellement du parc informatique`.

### Testing
- Aucun test automatisé exécuté car il s’agit d’un changement purement textuel.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6f0d0b6c833183300d5452cd6406)