### PR TITLE
Adjust yearly renewal allocations and budgets in RenouvellementInformatiqueTabs

### DIFF
--- a/src/components/RenouvellementInformatiqueTabs.tsx
+++ b/src/components/RenouvellementInformatiqueTabs.tsx
@@ -587,14 +587,14 @@ const RenouvellementInformatiqueTabs: React.FC = () => {
                   <tr>
                     <td className={tableCell}>Année 1</td>
                     <td className={tableCell}>9 matériels</td>
-                    <td className={tableCell}>1 PC Proviseur + 8 PC standards</td>
-                    <td className={tableCell}>3 600 000 FCFA</td>
+                    <td className={tableCell}>1 PC Proviseur + 1 PC Informaticien + 7 PC standards</td>
+                    <td className={tableCell}>3 950 000 FCFA</td>
                   </tr>
                   <tr>
                     <td className={tableCell}>Année 2</td>
                     <td className={tableCell}>9 matériels</td>
-                    <td className={tableCell}>1 PC Informaticien + 8 PC standards</td>
-                    <td className={tableCell}>3 605 000 FCFA</td>
+                    <td className={tableCell}>9 PC standards</td>
+                    <td className={tableCell}>3 244 500 FCFA</td>
                   </tr>
                   <tr>
                     <td className={tableCell}>Année 3</td>


### PR DESCRIPTION
### Motivation

- Correct the presented distribution of PC types and their estimated budgets in the 5-year renewal table to reflect the intended allocation (including the Informaticien machine in year 1) and updated cost totals.

### Description

- Update the Year 1 row in `RenouvellementInformatiqueTabs.tsx` to show `1 PC Proviseur + 1 PC Informaticien + 7 PC standards` and set the budget to `3 950 000 FCFA`.
- Update the Year 2 row to show `9 PC standards` and set the budget to `3 244 500 FCFA`.
- Leave Years 3–5 entries unchanged and keep the explanatory note about the 5-year renewal cycle.

### Testing

- Ran a TypeScript build with `npm run build` and the compilation completed successfully.
- Ran the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6f8d0b4083318fd899659618abe6)