### PR TITLE
Ajouter le lien Google Docs dans la section Plan de renouvellement informatique

### DIFF
--- a/src/components/RenouvellementInformatiqueTabs.tsx
+++ b/src/components/RenouvellementInformatiqueTabs.tsx
@@ -157,6 +157,17 @@ const RenouvellementInformatiqueTabs: React.FC = () => {
                 complet en une seule année. Chaque scénario est comparé au budget annuel des écolages
                 (1&nbsp;266&nbsp;470&nbsp;000 FCFA), afin d&apos;éclairer la décision stratégique à prendre.
               </p>
+              <p className="text-sm font-medium">
+                Détail du plan :
+                <a
+                  href="https://docs.google.com/document/d/1RfON8oACUVurB2ctBl_SzNNar_8rV-0x9yz-W5sjTtE/edit?tab=t.4r55qrg36osq"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ml-2 text-french-blue underline underline-offset-2 hover:text-french-blue/80"
+                >
+                  Consulter le Google Docs
+                </a>
+              </p>
             </div>
           </header>
 


### PR DESCRIPTION
### Motivation
- Ajouter un accès direct au document de détail du plan de renouvellement informatique depuis la page afin que les lecteurs puissent consulter le Google Docs de référence.

### Description
- Inséré un nouveau paragraphe contenant un lien externe `https://docs.google.com/document/d/1RfON8oACUVurB2ctBl_SzNNar_8rV-0x9yz-W5sjTtE/edit?tab=t.4r55qrg36osq` dans `src/components/RenouvellementInformatiqueTabs.tsx` avec `target="_blank"`, `rel="noopener noreferrer"` et des classes de style pour l’apparence.

### Testing
- Vérification automatique de la modification et du contenu du fichier effectuée avec une inspection de fichier (`nl -ba src/components/RenouvellementInformatiqueTabs.tsx | sed -n '150,220p'`) et l’outil de patch a signalé l’application réussie de la mise à jour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fd01f4ac83319e9d66a0205a0693)